### PR TITLE
feat: paypal commerce agent validation issue builder

### DIFF
--- a/src/Builder/AgenticCommerce/V1/MetaDataBuilder.php
+++ b/src/Builder/AgenticCommerce/V1/MetaDataBuilder.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Shopware\PayPalSDK\Builder\AgenticCommerce\V1;
+
+use Shopware\PayPalSDK\Struct\AgenticCommerce\V1\Referral\MetaData;
+use Shopware\PayPalSDK\Struct\AgenticCommerce\V1\ResolutionOption;
+
+final class MetaDataBuilder
+{
+    public function __construct(
+        private readonly ResolutionOption $resolutionOption,
+        private readonly ResolutionBuilder $resolutionBuilder,
+    ) {
+        if (!$this->resolutionOption->isset('metadata')) {
+            $this->resolutionOption->setMetadata(new MetaData());
+        }
+    }
+
+    public function withCostImpact(string $costImpact): self
+    {
+        $this->resolutionOption->getMetadata()->setCostImpact($costImpact);
+
+        return $this;
+    }
+
+    public function withWaist(string $waist): self
+    {
+        $this->resolutionOption->getMetadata()->setWaist($waist);
+
+        return $this;
+    }
+
+    public function withAutoApplicable(bool $autoApplicable): self
+    {
+        $this->resolutionOption->getMetadata()->setAutoApplicable($autoApplicable);
+
+        return $this;
+    }
+
+    public function withEstimatedTime(string $estimatedTime): self
+    {
+        $this->resolutionOption->getMetadata()->setEstimatedTime($estimatedTime);
+
+        return $this;
+    }
+
+    public function withRedirectRequired(bool $redirectRequired): self
+    {
+        $this->resolutionOption->getMetadata()->setRedirectRequired($redirectRequired);
+
+        return $this;
+    }
+
+    public function end(): ResolutionBuilder
+    {
+        return $this->resolutionBuilder;
+    }
+}

--- a/src/Builder/AgenticCommerce/V1/ResolutionBuilder.php
+++ b/src/Builder/AgenticCommerce/V1/ResolutionBuilder.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Shopware\PayPalSDK\Builder\AgenticCommerce\V1;
+
+use Shopware\PayPalSDK\Struct\AgenticCommerce\V1\ResolutionOption;
+use Shopware\PayPalSDK\Struct\AgenticCommerce\V1\ResolutionOptionCollection;
+use Shopware\PayPalSDK\Struct\AgenticCommerce\V1\ValidationIssue;
+
+final class ResolutionBuilder
+{
+    private ResolutionOption $resolution;
+
+    public function __construct(
+        private readonly ValidationIssue $issue,
+        private readonly ValidationIssueBuilder $validationIssueBuilder,
+    ) {
+        if (!$this->issue->isset('resolutionOptions')) {
+            $this->issue->setResolutionOptions(new ResolutionOptionCollection());
+        }
+
+        $this->resolution = new ResolutionOption();
+        $this->issue->getResolutionOptions()->add($this->resolution);
+    }
+
+    public function withAction(string $action): self
+    {
+        $this->resolution->setAction($action);
+
+        return $this;
+    }
+
+    public function withLabel(string $label): self
+    {
+        $this->resolution->setLabel($label);
+
+        return $this;
+    }
+
+    public function withUrl(string $url): self
+    {
+        $this->resolution->setUrl($url);
+
+        return $this;
+    }
+
+    public function withMetadata(): MetaDataBuilder
+    {
+        return new MetaDataBuilder($this->resolution, $this);
+    }
+
+    public function end(): ValidationIssueBuilder
+    {
+        return $this->validationIssueBuilder;
+    }
+}

--- a/src/Builder/AgenticCommerce/V1/ValidationIssueBuilder.php
+++ b/src/Builder/AgenticCommerce/V1/ValidationIssueBuilder.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Shopware\PayPalSDK\Builder\AgenticCommerce\V1;
+
+use Shopware\PayPalSDK\Struct\AgenticCommerce\V1\Context\AbstractContext;
+use Shopware\PayPalSDK\Struct\AgenticCommerce\V1\ResolutionOptionCollection;
+use Shopware\PayPalSDK\Struct\AgenticCommerce\V1\ValidationIssue;
+
+final class ValidationIssueBuilder
+{
+    private readonly ValidationIssue $issue;
+
+    public function __construct()
+    {
+        $this->issue = new ValidationIssue();
+    }
+
+    public function build(): ValidationIssue
+    {
+        return $this->issue;
+    }
+
+    public function withCode(string $code): self
+    {
+        $this->issue->setCode($code);
+
+        return $this;
+    }
+
+    public function withType(string $type): self
+    {
+        $this->issue->setType($type);
+
+        return $this;
+    }
+
+    public function withMessage(string $message): self
+    {
+        $this->issue->setMessage($message);
+
+        return $this;
+    }
+
+    public function withUserMessage(string $userMessage): self
+    {
+        $this->issue->setUserMessage($userMessage);
+
+        return $this;
+    }
+
+    public function withItemId(string $itemId): self
+    {
+        $this->issue->setItemId($itemId);
+
+        return $this;
+    }
+
+    public function withField(string $field): self
+    {
+        $this->issue->setField($field);
+
+        return $this;
+    }
+
+    public function withContext(AbstractContext $context): self
+    {
+        $this->issue->setContext($context);
+
+        return $this;
+    }
+
+    public function withResolutionOptions(ResolutionOptionCollection $resolutionOptions): self
+    {
+        $this->issue->setResolutionOptions($resolutionOptions);
+
+        return $this;
+    }
+
+    public function addResolutionOption(): ResolutionBuilder
+    {
+        return new ResolutionBuilder($this->issue, $this);
+    }
+}

--- a/tests/unit/Builder/AgenticCommerce/V1/MetaDataBuilderTest.php
+++ b/tests/unit/Builder/AgenticCommerce/V1/MetaDataBuilderTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Shopware\PayPalSDK\Tests\Unit\Builder\AgenticCommerce\V1;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\PayPalSDK\Builder\AgenticCommerce\V1\MetaDataBuilder;
+use Shopware\PayPalSDK\Builder\AgenticCommerce\V1\ResolutionBuilder;
+use Shopware\PayPalSDK\Builder\AgenticCommerce\V1\ValidationIssueBuilder;
+use Shopware\PayPalSDK\Struct\AgenticCommerce\V1\ResolutionOption;
+use Shopware\PayPalSDK\Struct\AgenticCommerce\V1\ValidationIssue;
+
+#[CoversClass(MetaDataBuilder::class)]
+class MetaDataBuilderTest extends TestCase
+{
+    public function testBuilder(): void
+    {
+        $option = new ResolutionOption();
+
+        $resolutionBuilder = new ResolutionBuilder(
+            new ValidationIssue(),
+            new ValidationIssueBuilder(),
+        );
+
+        $builder = new MetaDataBuilder($option, $resolutionBuilder);
+
+        $builder
+            ->withCostImpact('high')
+            ->withWaist('medium')
+            ->withAutoApplicable(true)
+            ->withEstimatedTime('2 hours')
+            ->withRedirectRequired(false);
+
+        $metaData = $option->getMetadata();
+
+        static::assertSame('high', $metaData->getCostImpact());
+        static::assertSame('medium', $metaData->getWaist());
+        static::assertTrue($metaData->isAutoApplicable());
+        static::assertSame('2 hours', $metaData->getEstimatedTime());
+        static::assertFalse($metaData->isRedirectRequired());
+
+        static::assertSame($resolutionBuilder, $builder->end());
+    }
+}

--- a/tests/unit/Builder/AgenticCommerce/V1/ResolutionBuilderTest.php
+++ b/tests/unit/Builder/AgenticCommerce/V1/ResolutionBuilderTest.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Shopware\PayPalSDK\Tests\Unit\Builder\AgenticCommerce\V1;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\PayPalSDK\Builder\AgenticCommerce\V1\ResolutionBuilder;
+use Shopware\PayPalSDK\Builder\AgenticCommerce\V1\ValidationIssueBuilder;
+use Shopware\PayPalSDK\Struct\AgenticCommerce\V1\ResolutionOption;
+use Shopware\PayPalSDK\Struct\AgenticCommerce\V1\ValidationIssue;
+
+#[CoversClass(ResolutionBuilder::class)]
+class ResolutionBuilderTest extends TestCase
+{
+    public function testBuilder(): void
+    {
+        $issue = new ValidationIssue();
+        $validationIssueBuilder = new ValidationIssueBuilder();
+        $resolutionBuilder = new ResolutionBuilder($issue, $validationIssueBuilder);
+
+        $resolutionBuilder
+            ->withAction(ResolutionOption::ACTION__ACCEPT_TERMS)
+            ->withLabel('label')
+            ->withUrl('https://example.com');
+
+        $resolutions = $issue->getResolutionOptions();
+
+        static::assertCount(1, $resolutions);
+
+        $resolution = $resolutions->first();
+
+        static::assertNotNull($resolution);
+        static::assertSame(ResolutionOption::ACTION__ACCEPT_TERMS, $resolution->getAction());
+        static::assertSame('label', $resolution->getLabel());
+        static::assertSame('https://example.com', $resolution->getUrl());
+
+        static::assertSame($validationIssueBuilder, $resolutionBuilder->end());
+    }
+
+    public function testWithMetaData(): void
+    {
+        $issue = new ValidationIssue();
+        $validationIssueBuilder = new ValidationIssueBuilder();
+        $resolutionBuilder = new ResolutionBuilder($issue, $validationIssueBuilder);
+
+        $resolutionBuilder
+            ->withMetadata()
+                ->withCostImpact('high')
+                ->withWaist('medium')
+                ->withAutoApplicable(true)
+                ->withEstimatedTime('2 hours')
+                ->withRedirectRequired(false);
+
+        $resolutions = $issue->getResolutionOptions();
+
+        static::assertCount(1, $resolutions);
+
+        $resolution = $resolutions->first();
+
+        static::assertNotNull($resolution);
+        static::assertSame('high', $resolution->getMetadata()->getCostImpact());
+        static::assertSame('medium', $resolution->getMetadata()->getWaist());
+        static::assertTrue($resolution->getMetadata()->isAutoApplicable());
+        static::assertSame('2 hours', $resolution->getMetadata()->getEstimatedTime());
+        static::assertFalse($resolution->getMetadata()->isRedirectRequired());
+
+        static::assertSame($validationIssueBuilder, $resolutionBuilder->end());
+    }
+}

--- a/tests/unit/Builder/AgenticCommerce/V1/ValidationIssueBuilderTest.php
+++ b/tests/unit/Builder/AgenticCommerce/V1/ValidationIssueBuilderTest.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Shopware\PayPalSDK\Tests\Unit\Builder\AgenticCommerce\V1;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\PayPalSDK\Builder\AgenticCommerce\V1\ValidationIssueBuilder;
+use Shopware\PayPalSDK\Struct\AgenticCommerce\V1\Context\InventoryIssueContext;
+use Shopware\PayPalSDK\Struct\AgenticCommerce\V1\ResolutionOption;
+use Shopware\PayPalSDK\Struct\AgenticCommerce\V1\ResolutionOptionCollection;
+use Shopware\PayPalSDK\Struct\AgenticCommerce\V1\ValidationIssue;
+
+#[CoversClass(ValidationIssueBuilder::class)]
+class ValidationIssueBuilderTest extends TestCase
+{
+    public function testBuilder(): void
+    {
+        $builder = new ValidationIssueBuilder();
+
+        $context = new InventoryIssueContext();
+        $options = new ResolutionOptionCollection([new ResolutionOption()]);
+
+        $issue = $builder
+            ->withContext($context)
+            ->withCode(ValidationIssue::CODE__INVENTORY_ISSUE)
+            ->withType(ValidationIssue::TYPE__BUSINESS_RULE)
+            ->withMessage('The request is invalid.')
+            ->withUserMessage('Please check your input and try again.')
+            ->withItemId('item123')
+            ->withField('email')
+            ->withResolutionOptions($options)
+            ->build();
+
+        static::assertSame($context, $issue->getContext());
+        static::assertSame(ValidationIssue::CODE__INVENTORY_ISSUE, $issue->getCode());
+        static::assertSame(ValidationIssue::TYPE__BUSINESS_RULE, $issue->getType());
+        static::assertSame('The request is invalid.', $issue->getMessage());
+        static::assertSame('Please check your input and try again.', $issue->getUserMessage());
+        static::assertSame('item123', $issue->getItemId());
+        static::assertSame('email', $issue->getField());
+        static::assertSame($options, $issue->getResolutionOptions());
+    }
+
+    public function testCompleteBuild(): void
+    {
+        $builder = new ValidationIssueBuilder();
+
+        $issue = $builder
+            ->addResolutionOption()
+                ->withLabel('Remove item')
+                ->withUrl('https://example.com/remove')
+                ->withAction(ResolutionOption::ACTION__ACCEPT_TERMS)
+                ->withMetadata()
+                    ->withCostImpact('high')
+                    ->withWaist('medium')
+                    ->withAutoApplicable(true)
+                    ->withEstimatedTime('2 hours')
+                    ->withRedirectRequired(false)
+                    ->end()
+                ->end()
+            ->addResolutionOption()
+                ->withLabel('Contact support')
+                ->withUrl('https://example.com/contact')
+                ->withAction(ResolutionOption::ACTION__CONTACT_SUPPORT)
+                ->withMetadata()
+                    ->withCostImpact('low')
+                    ->withWaist('low')
+                    ->withAutoApplicable(false)
+                    ->withEstimatedTime('1 hour')
+                    ->withRedirectRequired(true)
+                    ->end()
+                ->end()
+            ->build();
+
+        static::assertCount(2, $issue->getResolutionOptions());
+        $resolutions = $issue->getResolutionOptions();
+
+        $firstResolution = $resolutions->first();
+        static::assertNotNull($firstResolution);
+        static::assertSame('Remove item', $firstResolution->getLabel());
+        static::assertSame('https://example.com/remove', $firstResolution->getUrl());
+        static::assertSame(ResolutionOption::ACTION__ACCEPT_TERMS, $firstResolution->getAction());
+        static::assertSame('high', $firstResolution->getMetadata()->getCostImpact());
+        static::assertSame('medium', $firstResolution->getMetadata()->getWaist());
+        static::assertTrue($firstResolution->getMetadata()->isAutoApplicable());
+        static::assertSame('2 hours', $firstResolution->getMetadata()->getEstimatedTime());
+        static::assertFalse($firstResolution->getMetadata()->isRedirectRequired());
+
+        $secondResolution = $resolutions->last();
+        static::assertNotNull($secondResolution);
+        static::assertSame('Contact support', $secondResolution->getLabel());
+        static::assertSame('https://example.com/contact', $secondResolution->getUrl());
+        static::assertSame(ResolutionOption::ACTION__CONTACT_SUPPORT, $secondResolution->getAction());
+        static::assertSame('low', $secondResolution->getMetadata()->getCostImpact());
+        static::assertSame('low', $secondResolution->getMetadata()->getWaist());
+        static::assertFalse($secondResolution->getMetadata()->isAutoApplicable());
+        static::assertSame('1 hour', $secondResolution->getMetadata()->getEstimatedTime());
+        static::assertTrue($secondResolution->getMetadata()->isRedirectRequired());
+    }
+}


### PR DESCRIPTION
Validation issue builder for complex response type of validation issues during agent commerce cart errors / business rule errors and such.

Used like this:

```php
        $builder = new ValidationIssueBuilder();

        $issue = $builder
            ->addResolutionOption()
                ->withLabel('Remove item')
                ->withUrl('https://example.com/remove')
                ->withAction(ResolutionOption::ACTION__ACCEPT_TERMS)
                ->withMetadata()
                    ->withCostImpact('high')
                    ->withWaist('medium')
                    ->withAutoApplicable(true)
                    ->withEstimatedTime('2 hours')
                    ->withRedirectRequired(false)
                    ->end()
                ->end()
            ->addResolutionOption()
                ->withLabel('Contact support')
                ->withUrl('https://example.com/contact')
                ->withAction(ResolutionOption::ACTION__CONTACT_SUPPORT)
                ->withMetadata()
                    ->withCostImpact('low')
                    ->withWaist('low')
                    ->withAutoApplicable(false)
                    ->withEstimatedTime('1 hour')
                    ->withRedirectRequired(true)
                    ->end()
                ->end()
            ->build();
```