### PR TITLE
feat: Add callback config for PayPal Express Checkout context

### DIFF
--- a/src/Struct/V2/Order/PaymentSource/Common/Attributes/OrderUpdateCallbackConfig.php
+++ b/src/Struct/V2/Order/PaymentSource/Common/Attributes/OrderUpdateCallbackConfig.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Common\Attributes;
+
+use OpenApi\Attributes as OA;
+use Shopware\PayPalSDK\Struct\Struct;
+
+#[OA\Schema(schema: 'paypal_v2_order_payment_source_common_attributes_order_update_callback_config')]
+class OrderUpdateCallbackConfig extends Struct
+{
+    public const CALLBACK_EVENT_SHIPPING_ADDRESS = 'SHIPPING_ADDRESS';
+    public const CALLBACK_EVENT_SHIPPING_OPTIONS = 'SHIPPING_OPTIONS';
+
+    #[OA\Property(type: 'string')]
+    protected string $callbackUrl;
+
+    /**
+     * @var string[]
+     */
+    #[OA\Property(type: 'array', items: new OA\Items(type: 'string', enum: [self::CALLBACK_EVENT_SHIPPING_ADDRESS, self::CALLBACK_EVENT_SHIPPING_OPTIONS]))]
+    protected array $callbackEvents;
+
+    public function getCallbackUrl(): string
+    {
+        return $this->callbackUrl;
+    }
+
+    public function setCallbackUrl(string $callbackUrl): void
+    {
+        $this->callbackUrl = $callbackUrl;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getCallbackEvents(): array
+    {
+        return $this->callbackEvents;
+    }
+
+    /**
+     * @param string[] $callbackEvents
+     */
+    public function setCallbackEvents(array $callbackEvents): void
+    {
+        $this->callbackEvents = $callbackEvents;
+    }
+}

--- a/src/Struct/V2/Order/PaymentSource/Common/Attributes/OrderUpdateCallbackConfig.php
+++ b/src/Struct/V2/Order/PaymentSource/Common/Attributes/OrderUpdateCallbackConfig.php
@@ -19,9 +19,7 @@ class OrderUpdateCallbackConfig extends Struct
     #[OA\Property(type: 'string')]
     protected string $callbackUrl;
 
-    /**
-     * @var string[]
-     */
+    /** @var string[] */
     #[OA\Property(type: 'array', items: new OA\Items(type: 'string', enum: [self::CALLBACK_EVENT_SHIPPING_ADDRESS, self::CALLBACK_EVENT_SHIPPING_OPTIONS]))]
     protected array $callbackEvents;
 

--- a/src/Struct/V2/Order/PaymentSource/Common/ExperienceContext.php
+++ b/src/Struct/V2/Order/PaymentSource/Common/ExperienceContext.php
@@ -9,6 +9,7 @@ namespace Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Common;
 
 use OpenApi\Attributes as OA;
 use Shopware\PayPalSDK\Struct\Struct;
+use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Common\Attributes\OrderUpdateCallbackConfig;
 
 #[OA\Schema(schema: 'paypal_v2_order_payment_source_common_experience_context')]
 class ExperienceContext extends Struct
@@ -69,6 +70,9 @@ class ExperienceContext extends Struct
      */
     #[OA\Property(type: 'array', items: new OA\Items(type: 'string'))]
     protected array $customerServiceInstructions;
+
+    #[OA\Property(ref: '#/components/schemas/paypal_v2_order_payment_source_common_attributes_order_update_callback_config')]
+    protected ?OrderUpdateCallbackConfig $orderUpdateCallbackConfig = null;
 
     public function getLocale(): string
     {
@@ -174,5 +178,15 @@ class ExperienceContext extends Struct
     public function setCustomerServiceInstructions(array $customerServiceInstructions): void
     {
         $this->customerServiceInstructions = $customerServiceInstructions;
+    }
+
+    public function getOrderUpdateCallbackConfig(): ?OrderUpdateCallbackConfig
+    {
+        return $this->orderUpdateCallbackConfig;
+    }
+
+    public function setOrderUpdateCallbackConfig(?OrderUpdateCallbackConfig $orderUpdateCallbackConfig): void
+    {
+        $this->orderUpdateCallbackConfig = $orderUpdateCallbackConfig;
     }
 }

--- a/src/Struct/V2/Order/PaymentSource/Common/ExperienceContext.php
+++ b/src/Struct/V2/Order/PaymentSource/Common/ExperienceContext.php
@@ -71,7 +71,7 @@ class ExperienceContext extends Struct
     #[OA\Property(type: 'array', items: new OA\Items(type: 'string'))]
     protected array $customerServiceInstructions;
 
-    #[OA\Property(ref: '#/components/schemas/paypal_v2_order_payment_source_common_attributes_order_update_callback_config')]
+    #[OA\Property(ref: OrderUpdateCallbackConfig::class)]
     protected ?OrderUpdateCallbackConfig $orderUpdateCallbackConfig = null;
 
     public function getLocale(): string


### PR DESCRIPTION
### 1. Why is this change necessary?
- Blocking https://github.com/shopware/SwagPayPal/pull/403

### 2. What does this change do, exactly?
- `OrderUpdateCallbackConfig.php`
    - New class for callback configuration
    - Supports `callback_url` and `callback_events` fields
- `ExperienceContext.php`
    - Added `orderUpdateCallbackConfig` property
    - Added getter/setter methods

### 3. Describe each step to reproduce the issue or behaviour.
- See https://github.com/shopware/SwagPayPal/issues/342 - Actual behavior.

### 4. Please link to the relevant issues (if any).
- Closes https://github.com/shopware/SwagPayPal/issues/342
- Blocking https://github.com/shopware/SwagPayPal/pull/403

