### PR TITLE
fix: token caching

### DIFF
--- a/src/Gateway/TokenGateway.php
+++ b/src/Gateway/TokenGateway.php
@@ -86,6 +86,6 @@ class TokenGateway implements TokenGatewayInterface
             return;
         }
 
-        $this->tokenCache->set($key, $token, $token->getExpiresIn() - Token::TTL_THRESHOLD_SEC);
+        $this->tokenCache->set($key, $token, (int) ($token->getExpiresIn() * Token::TTL_THRESHOLD_PERCENT));
     }
 }

--- a/src/Struct/V1/Token.php
+++ b/src/Struct/V1/Token.php
@@ -67,7 +67,7 @@ class Token extends Struct
         $newToken = parent::assign($data);
 
         // Calculate the expiration date manually
-        $expiresIn = $newToken->expiresIn * self::TTL_THRESHOLD_PERCENT;
+        $expiresIn = (int) ($newToken->expiresIn * self::TTL_THRESHOLD_PERCENT);
         $newToken->expireDateTime = new \DateTime("now + {$expiresIn} seconds", new \DateTimeZone('UTC'));
 
         return $newToken;

--- a/src/Struct/V1/Token.php
+++ b/src/Struct/V1/Token.php
@@ -13,7 +13,12 @@ use Shopware\PayPalSDK\Struct\Struct;
 #[OA\Schema(schema: 'paypal_v1_token')]
 class Token extends Struct
 {
+    /**
+     * @deprecated tag:v2.0.0 - Will be removed and is replaced by {@see self::TTL_THRESHOLD_PERCENT}
+     */
     public const TTL_THRESHOLD_SEC = 60 * 60;
+
+    public const TTL_THRESHOLD_PERCENT = 0.95; // -5%
 
     /**
      * Scopes expressed in the form of resource URL endpoints. The value of the scope parameter
@@ -62,9 +67,8 @@ class Token extends Struct
         $newToken = parent::assign($data);
 
         // Calculate the expiration date manually
-        $expirationDateTime = new \DateTime('now', new \DateTimeZone('UTC'));
-        $interval = \DateInterval::createFromDateString(\sprintf('%s seconds', $newToken->expiresIn - self::TTL_THRESHOLD_SEC));
-        $newToken->expireDateTime = $expirationDateTime->add($interval ?: new \DateInterval('PT0S'));
+        $expiresIn = $newToken->expiresIn * self::TTL_THRESHOLD_PERCENT;
+        $newToken->expireDateTime = new \DateTime("now + {$expiresIn} seconds", new \DateTimeZone('UTC'));
 
         return $newToken;
     }


### PR DESCRIPTION
`Token::TTL_THRESHOLD_SEC` is not sustainable for tokens like the client token due to its short lifetime.
Instead, we should remove a percentage of ~5% 