### PR TITLE
fix: add VaultedPaymentSourceInterface

### DIFF
--- a/src/Contract/Struct/V2/Order/PaymentSource/VaultedPaymentSourceInterface.php
+++ b/src/Contract/Struct/V2/Order/PaymentSource/VaultedPaymentSourceInterface.php
@@ -9,7 +9,7 @@ namespace Shopware\PayPalSDK\Contract\Struct\V2\Order\PaymentSource;
 
 use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Common\Attributes;
 
-interface VaultedPaymentSourceInterface
+interface VaultedPaymentSourceInterface extends VaultablePaymentSourceInterface
 {
     public function getAttributes(): ?Attributes;
 

--- a/src/Contract/Struct/V2/Order/PaymentSource/VaultedPaymentSourceInterface.php
+++ b/src/Contract/Struct/V2/Order/PaymentSource/VaultedPaymentSourceInterface.php
@@ -9,14 +9,15 @@ namespace Shopware\PayPalSDK\Contract\Struct\V2\Order\PaymentSource;
 
 use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Common\Attributes;
 
-/**
- * @deprecated tag:v2.0.0 - will be removed in favor of VaultedPaymentSourceInterface, which will be implemented by all vaultable payment sources and contains the vaultId property.
- */
-interface VaultablePaymentSourceInterface
+interface VaultedPaymentSourceInterface
 {
     public function getAttributes(): ?Attributes;
 
     public function setAttributes(?Attributes $attributes): void;
+
+    public function getVaultId(): string;
+
+    public function setVaultId(string $vaultId): void;
 
     public function getVaultIdentifier(): string;
 }

--- a/src/Struct/V2/Order/PaymentSource/Card.php
+++ b/src/Struct/V2/Order/PaymentSource/Card.php
@@ -9,13 +9,14 @@ namespace Shopware\PayPalSDK\Struct\V2\Order\PaymentSource;
 
 use OpenApi\Attributes as OA;
 use Shopware\PayPalSDK\Contract\Struct\V2\Order\PaymentSource\VaultablePaymentSourceInterface;
+use Shopware\PayPalSDK\Contract\Struct\V2\Order\PaymentSource\VaultedPaymentSourceInterface;
 use Shopware\PayPalSDK\Struct\V2\Common\Address;
 use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Card\AuthenticationResult;
 use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Card\StoredCredential;
 use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Common\Attributes;
 
 #[OA\Schema(schema: 'paypal_v2_order_payment_source_card')]
-class Card extends AbstractAPMPaymentSource implements VaultablePaymentSourceInterface
+class Card extends AbstractAPMPaymentSource implements VaultablePaymentSourceInterface, VaultedPaymentSourceInterface
 {
     #[OA\Property(type: 'string')]
     protected string $lastDigits;

--- a/src/Struct/V2/Order/PaymentSource/Card.php
+++ b/src/Struct/V2/Order/PaymentSource/Card.php
@@ -8,7 +8,6 @@
 namespace Shopware\PayPalSDK\Struct\V2\Order\PaymentSource;
 
 use OpenApi\Attributes as OA;
-use Shopware\PayPalSDK\Contract\Struct\V2\Order\PaymentSource\VaultablePaymentSourceInterface;
 use Shopware\PayPalSDK\Contract\Struct\V2\Order\PaymentSource\VaultedPaymentSourceInterface;
 use Shopware\PayPalSDK\Struct\V2\Common\Address;
 use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Card\AuthenticationResult;
@@ -16,7 +15,7 @@ use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Card\StoredCredential;
 use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Common\Attributes;
 
 #[OA\Schema(schema: 'paypal_v2_order_payment_source_card')]
-class Card extends AbstractAPMPaymentSource implements VaultablePaymentSourceInterface, VaultedPaymentSourceInterface
+class Card extends AbstractAPMPaymentSource implements VaultedPaymentSourceInterface
 {
     #[OA\Property(type: 'string')]
     protected string $lastDigits;

--- a/src/Struct/V2/Order/PaymentSource/Paypal.php
+++ b/src/Struct/V2/Order/PaymentSource/Paypal.php
@@ -9,13 +9,14 @@ namespace Shopware\PayPalSDK\Struct\V2\Order\PaymentSource;
 
 use OpenApi\Attributes as OA;
 use Shopware\PayPalSDK\Contract\Struct\V2\Order\PaymentSource\VaultablePaymentSourceInterface;
+use Shopware\PayPalSDK\Contract\Struct\V2\Order\PaymentSource\VaultedPaymentSourceInterface;
 use Shopware\PayPalSDK\Struct\V2\Common\Address;
 use Shopware\PayPalSDK\Struct\V2\Common\Name;
 use Shopware\PayPalSDK\Struct\V2\Common\PhoneNumber;
 use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Common\Attributes;
 
 #[OA\Schema(schema: 'paypal_v2_order_payment_source_paypal')]
-class Paypal extends AbstractPaymentSource implements VaultablePaymentSourceInterface
+class Paypal extends AbstractPaymentSource implements VaultablePaymentSourceInterface, VaultedPaymentSourceInterface
 {
     #[OA\Property(type: 'string')]
     protected string $emailAddress;

--- a/src/Struct/V2/Order/PaymentSource/Paypal.php
+++ b/src/Struct/V2/Order/PaymentSource/Paypal.php
@@ -8,7 +8,6 @@
 namespace Shopware\PayPalSDK\Struct\V2\Order\PaymentSource;
 
 use OpenApi\Attributes as OA;
-use Shopware\PayPalSDK\Contract\Struct\V2\Order\PaymentSource\VaultablePaymentSourceInterface;
 use Shopware\PayPalSDK\Contract\Struct\V2\Order\PaymentSource\VaultedPaymentSourceInterface;
 use Shopware\PayPalSDK\Struct\V2\Common\Address;
 use Shopware\PayPalSDK\Struct\V2\Common\Name;
@@ -16,7 +15,7 @@ use Shopware\PayPalSDK\Struct\V2\Common\PhoneNumber;
 use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Common\Attributes;
 
 #[OA\Schema(schema: 'paypal_v2_order_payment_source_paypal')]
-class Paypal extends AbstractPaymentSource implements VaultablePaymentSourceInterface, VaultedPaymentSourceInterface
+class Paypal extends AbstractPaymentSource implements VaultedPaymentSourceInterface
 {
     #[OA\Property(type: 'string')]
     protected string $emailAddress;

--- a/src/Struct/V2/Order/PaymentSource/Venmo.php
+++ b/src/Struct/V2/Order/PaymentSource/Venmo.php
@@ -9,13 +9,14 @@ namespace Shopware\PayPalSDK\Struct\V2\Order\PaymentSource;
 
 use OpenApi\Attributes as OA;
 use Shopware\PayPalSDK\Contract\Struct\V2\Order\PaymentSource\VaultablePaymentSourceInterface;
+use Shopware\PayPalSDK\Contract\Struct\V2\Order\PaymentSource\VaultedPaymentSourceInterface;
 use Shopware\PayPalSDK\Struct\V2\Common\Address;
 use Shopware\PayPalSDK\Struct\V2\Common\Name;
 use Shopware\PayPalSDK\Struct\V2\Common\PhoneNumber;
 use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Common\Attributes;
 
 #[OA\Schema(schema: 'paypal_v2_order_payment_source_venmo')]
-class Venmo extends AbstractPaymentSource implements VaultablePaymentSourceInterface
+class Venmo extends AbstractPaymentSource implements VaultablePaymentSourceInterface, VaultedPaymentSourceInterface
 {
     #[OA\Property(type: 'string')]
     protected string $emailAddress;

--- a/src/Struct/V2/Order/PaymentSource/Venmo.php
+++ b/src/Struct/V2/Order/PaymentSource/Venmo.php
@@ -8,7 +8,6 @@
 namespace Shopware\PayPalSDK\Struct\V2\Order\PaymentSource;
 
 use OpenApi\Attributes as OA;
-use Shopware\PayPalSDK\Contract\Struct\V2\Order\PaymentSource\VaultablePaymentSourceInterface;
 use Shopware\PayPalSDK\Contract\Struct\V2\Order\PaymentSource\VaultedPaymentSourceInterface;
 use Shopware\PayPalSDK\Struct\V2\Common\Address;
 use Shopware\PayPalSDK\Struct\V2\Common\Name;
@@ -16,7 +15,7 @@ use Shopware\PayPalSDK\Struct\V2\Common\PhoneNumber;
 use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Common\Attributes;
 
 #[OA\Schema(schema: 'paypal_v2_order_payment_source_venmo')]
-class Venmo extends AbstractPaymentSource implements VaultablePaymentSourceInterface, VaultedPaymentSourceInterface
+class Venmo extends AbstractPaymentSource implements VaultedPaymentSourceInterface
 {
     #[OA\Property(type: 'string')]
     protected string $emailAddress;


### PR DESCRIPTION
It is very advantageous to have the vault id also in the interface.
Since adding a property to an interface is a breaking change, I created a new interface.
I also thought about adding an abstract class in between, but there are already different parent classes among these payment sources.