### PR TITLE
fix: OpenAPI schema types for empty object structs

### DIFF
--- a/src/Struct/V1/Payment/Transaction/ItemList/ShippingOption.php
+++ b/src/Struct/V1/Payment/Transaction/ItemList/ShippingOption.php
@@ -12,7 +12,8 @@ use Shopware\PayPalSDK\Struct\Struct;
 
 #[OA\Schema(
     schema: 'paypal_v1_payment_transaction_item_list_shipping_option',
-    properties: [], // so an empty object will be generated
+    type: 'object',
+    properties: [],
 )]
 class ShippingOption extends Struct
 {

--- a/src/Struct/V2/EligibleMethodsData/EligibleMethods/Bancontact.php
+++ b/src/Struct/V2/EligibleMethodsData/EligibleMethods/Bancontact.php
@@ -13,7 +13,7 @@ use Shopware\PayPalSDK\Struct\Struct;
 /**
  * @experimental
  */
-#[OA\Schema(schema: 'paypal_v2_eligible_methods_data_eligible_methods_bancontact')]
+#[OA\Schema(schema: 'paypal_v2_eligible_methods_data_eligible_methods_bancontact', type: 'object')]
 class Bancontact extends Struct
 {
 }

--- a/src/Struct/V2/EligibleMethodsData/EligibleMethods/Bizum.php
+++ b/src/Struct/V2/EligibleMethodsData/EligibleMethods/Bizum.php
@@ -13,7 +13,7 @@ use Shopware\PayPalSDK\Struct\Struct;
 /**
  * @experimental
  */
-#[OA\Schema(schema: 'paypal_v2_eligible_methods_data_eligible_methods_bizum')]
+#[OA\Schema(schema: 'paypal_v2_eligible_methods_data_eligible_methods_bizum', type: 'object')]
 class Bizum extends Struct
 {
 }

--- a/src/Struct/V2/EligibleMethodsData/EligibleMethods/Blik.php
+++ b/src/Struct/V2/EligibleMethodsData/EligibleMethods/Blik.php
@@ -13,7 +13,7 @@ use Shopware\PayPalSDK\Struct\Struct;
 /**
  * @experimental
  */
-#[OA\Schema(schema: 'paypal_v2_eligible_methods_data_eligible_methods_blik')]
+#[OA\Schema(schema: 'paypal_v2_eligible_methods_data_eligible_methods_blik', type: 'object')]
 class Blik extends Struct
 {
 }

--- a/src/Struct/V2/EligibleMethodsData/EligibleMethods/Eps.php
+++ b/src/Struct/V2/EligibleMethodsData/EligibleMethods/Eps.php
@@ -13,7 +13,7 @@ use Shopware\PayPalSDK\Struct\Struct;
 /**
  * @experimental
  */
-#[OA\Schema(schema: 'paypal_v2_eligible_methods_data_eligible_methods_eps')]
+#[OA\Schema(schema: 'paypal_v2_eligible_methods_data_eligible_methods_eps', type: 'object')]
 class Eps extends Struct
 {
 }

--- a/src/Struct/V2/EligibleMethodsData/EligibleMethods/Ideal.php
+++ b/src/Struct/V2/EligibleMethodsData/EligibleMethods/Ideal.php
@@ -13,7 +13,7 @@ use Shopware\PayPalSDK\Struct\Struct;
 /**
  * @experimental
  */
-#[OA\Schema(schema: 'paypal_v2_eligible_methods_data_eligible_methods_ideal')]
+#[OA\Schema(schema: 'paypal_v2_eligible_methods_data_eligible_methods_ideal', type: 'object')]
 class Ideal extends Struct
 {
 }

--- a/src/Struct/V2/EligibleMethodsData/EligibleMethods/Klarna.php
+++ b/src/Struct/V2/EligibleMethodsData/EligibleMethods/Klarna.php
@@ -13,7 +13,7 @@ use Shopware\PayPalSDK\Struct\Struct;
 /**
  * @experimental
  */
-#[OA\Schema(schema: 'paypal_v2_eligible_methods_data_eligible_methods_klarna')]
+#[OA\Schema(schema: 'paypal_v2_eligible_methods_data_eligible_methods_klarna', type: 'object')]
 class Klarna extends Struct
 {
 }

--- a/src/Struct/V2/EligibleMethodsData/EligibleMethods/P24.php
+++ b/src/Struct/V2/EligibleMethodsData/EligibleMethods/P24.php
@@ -13,7 +13,7 @@ use Shopware\PayPalSDK\Struct\Struct;
 /**
  * @experimental
  */
-#[OA\Schema(schema: 'paypal_v2_eligible_methods_data_eligible_methods_p24')]
+#[OA\Schema(schema: 'paypal_v2_eligible_methods_data_eligible_methods_p24', type: 'object')]
 class P24 extends Struct
 {
 }

--- a/src/Struct/V3/ManagedAccount/BusinessEntity/IncorporationDetails.php
+++ b/src/Struct/V3/ManagedAccount/BusinessEntity/IncorporationDetails.php
@@ -10,7 +10,7 @@ namespace Shopware\PayPalSDK\Struct\V3\ManagedAccount\BusinessEntity;
 use OpenApi\Attributes as OA;
 use Shopware\PayPalSDK\Struct\Struct;
 
-#[OA\Schema(schema: 'paypal_v3_managed_account_business_entity_incorporation_details')]
+#[OA\Schema(schema: 'paypal_v3_managed_account_business_entity_incorporation_details', type: 'object')]
 class IncorporationDetails extends Struct
 {
 }

--- a/tests/integration/Struct/OpenAPISchemaTest.php
+++ b/tests/integration/Struct/OpenAPISchemaTest.php
@@ -16,6 +16,7 @@ use OpenApi\Attributes\Property;
 use OpenApi\Generator;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
+use Shopware\PayPalSDK\Struct\Struct;
 use Shopware\PayPalSDK\Util\CaseConverter;
 
 /**
@@ -118,6 +119,35 @@ class OpenAPISchemaTest extends TestCase
 
             if ($expectedSchema !== $schema->schema) {
                 $failures[] = $class . ' was expected to have a schema name of "' . $expectedSchema . '" but has "' . $schema->schema . '" instead.';
+            }
+        }
+
+        static::assertEmpty($failures, \implode(\PHP_EOL, $failures));
+    }
+
+    public function testEmptyStructSchemasAreObjects(): void
+    {
+        $failures = [];
+
+        foreach ($this->oa->_analysis->classes as $class => $classContext) {
+            $schema = $this->oa->_analysis->getSchemaForSource($class);
+
+            if (!$schema?->schema || $schema->schema === Generator::UNDEFINED || !\class_exists($class)) {
+                continue;
+            }
+
+            $refClass = new \ReflectionClass($class);
+
+            if (
+                $refClass->isAbstract()
+                || !$refClass->isSubclassOf(Struct::class)
+                || \count($refClass->getProperties()) > 0
+            ) {
+                continue;
+            }
+
+            if ($schema->type !== 'object') {
+                $failures[] = $class . ' is an empty struct but its schema type is not "object".';
             }
         }
 


### PR DESCRIPTION
## Summary
- add `type: 'object'` to empty struct OpenAPI schemas that were emitted without an explicit object type
- cover both legacy `properties: []` and annotation-only empty structs in the schema definitions
- add an integration test to ensure empty `Struct` subclasses always generate object schemas

relates to shopware/SwagPayPal#563