### PR TITLE
fix: limit SepaExperienceContext fields

### DIFF
--- a/src/Struct/V2/Order/PaymentSource/Bank/SepaExperienceContext.php
+++ b/src/Struct/V2/Order/PaymentSource/Bank/SepaExperienceContext.php
@@ -15,11 +15,12 @@ class SepaExperienceContext extends ExperienceContext
 {
     public function jsonSerialize(): array
     {
+        $data = parent::jsonSerialize();
+
         return \array_filter([
-            ...parent::jsonSerialize(),
-            'landing_page' => null,
-            'shipping_preference' => null,
-            'user_action' => null,
+            'locale' => $data['locale'] ?? null,
+            'return_url' => $data['return_url'] ?? null,
+            'cancel_url' => $data['cancel_url'] ?? null,
         ]);
     }
 }


### PR DESCRIPTION
Since most custom `SepaExperienceContext` fields (such as `brand_name`, `logo_url`, `customer_service_instructions` and...) can break this payment method, I’ve limited them to those documented by PayPal to avoid issues when merchants enable additional fields.