### PR TITLE
fix: third party client token caching

### DIFF
--- a/src/Context/CredentialsOAuthContext.php
+++ b/src/Context/CredentialsOAuthContext.php
@@ -30,9 +30,10 @@ class CredentialsOAuthContext implements CredentialsOAuthContextInterface
     public function getCacheKey(ApiContextInterface $context): ?string
     {
         return \hash('xxh128', \sprintf(
-            'credentials-%s-%s-%s',
+            'credentials-%s-%s-%s-%s',
             $this->clientId,
             $this->clientSecret,
+            (string) ($context->isThirdParty() ? $context->getMerchantId() : null),
             $context->isSandbox() ? 'true' : 'false',
         ));
     }

--- a/tests/unit/Context/ClientTokenOAuthContextTest.php
+++ b/tests/unit/Context/ClientTokenOAuthContextTest.php
@@ -44,8 +44,8 @@ class ClientTokenOAuthContextTest extends TestCase
 
         $context = new ApiContext($oauthContext, true);
 
-        static::assertSame('83b27fb1aba69ca6df73f52b7323b28f', $oauthContext->getCacheKey($context));
-        static::assertSame('7c9d85e352fd8fe30e4c1ca88e266e99', $oauthContext->getCacheKey($context->withSandbox(false)));
+        static::assertSame('dc819654e13a5407a9193e81bc5070da', $oauthContext->getCacheKey($context));
+        static::assertSame('38e0d409e33ce4f3be0e654f5c40cc7f', $oauthContext->getCacheKey($context->withSandbox(false)));
     }
 
     public function testDebugInformationSensitive(): void

--- a/tests/unit/Context/CredentialsOAuthContextTest.php
+++ b/tests/unit/Context/CredentialsOAuthContextTest.php
@@ -40,7 +40,11 @@ class CredentialsOAuthContextTest extends TestCase
         static::assertSame('811d31b1a38f983389f5ea9282138dc6', $oauthContext->getCacheKey($context));
         static::assertSame('07d2bb003e7335920000cd7050f8c839', $oauthContext->getCacheKey($context->withSandbox(false)));
 
-        $context = $context->withThirdParty(true)->withMerchantId('some-merchant-id');
+        $context = $context->withThirdParty(false)->withMerchantId('some-merchant-id');
+        static::assertSame('811d31b1a38f983389f5ea9282138dc6', $oauthContext->getCacheKey($context));
+
+        // cache key has to be differ from the ones above if third-party and merchant id is set
+        $context = $context->withThirdParty(true);
         static::assertSame('e5962bdc163c23423cff6c704e598863', $oauthContext->getCacheKey($context));
     }
 

--- a/tests/unit/Context/CredentialsOAuthContextTest.php
+++ b/tests/unit/Context/CredentialsOAuthContextTest.php
@@ -37,8 +37,11 @@ class CredentialsOAuthContextTest extends TestCase
 
         $context = new ApiContext($oauthContext, true);
 
-        static::assertSame('806098f9f6e2fbbe6b3f402dad7c0220', $oauthContext->getCacheKey($context));
-        static::assertSame('86ab9591f53eba173b77612390d2416a', $oauthContext->getCacheKey($context->withSandbox(false)));
+        static::assertSame('811d31b1a38f983389f5ea9282138dc6', $oauthContext->getCacheKey($context));
+        static::assertSame('07d2bb003e7335920000cd7050f8c839', $oauthContext->getCacheKey($context->withSandbox(false)));
+
+        $context = $context->withThirdParty(true)->withMerchantId('some-merchant-id');
+        static::assertSame('e5962bdc163c23423cff6c704e598863', $oauthContext->getCacheKey($context));
     }
 
     public function testIntoUserIdContext(): void
@@ -50,7 +53,7 @@ class CredentialsOAuthContextTest extends TestCase
 
         /** @phpstan-ignore-next-line staticMethod.alreadyNarrowedType - still worth the assertion */
         static::assertInstanceOf(UserIdOAuthContext::class, $oauthContext);
-        static::assertSame('53bf912f9ef7bee5ce0e44d7644f5566', $oauthContext->getCacheKey($context));
+        static::assertSame('80df4af5b9a9bc898ed7a417362877dc', $oauthContext->getCacheKey($context));
     }
 
     public function testIntoUserIdContextWithoutId(): void
@@ -60,7 +63,7 @@ class CredentialsOAuthContextTest extends TestCase
 
         $context = new ApiContext($oauthContext, true);
 
-        static::assertSame('db4395115b84188b4fe25782e010ac8c', $oauthContext->getCacheKey($context));
+        static::assertSame('2088739d61790f3ccd0135f7bb22c118', $oauthContext->getCacheKey($context));
     }
 
     public function testIntoClientTokenContext(): void
@@ -72,7 +75,7 @@ class CredentialsOAuthContextTest extends TestCase
 
         /** @phpstan-ignore-next-line staticMethod.alreadyNarrowedType - still worth the assertion */
         static::assertInstanceOf(ClientTokenOAuthContext::class, $oauthContext);
-        static::assertSame('83b27fb1aba69ca6df73f52b7323b28f', $oauthContext->getCacheKey($context));
+        static::assertSame('dc819654e13a5407a9193e81bc5070da', $oauthContext->getCacheKey($context));
     }
 
     public function testDebugInformationSensitive(): void

--- a/tests/unit/Context/UserIdOAuthContextTest.php
+++ b/tests/unit/Context/UserIdOAuthContextTest.php
@@ -47,8 +47,8 @@ class UserIdOAuthContextTest extends TestCase
 
         $context = new ApiContext($oauthContext, true);
 
-        static::assertSame('53bf912f9ef7bee5ce0e44d7644f5566', $oauthContext->getCacheKey($context));
-        static::assertSame('38cc2b78bcff06448a4607ff03ff2f57', $oauthContext->getCacheKey($context->withSandbox(false)));
+        static::assertSame('80df4af5b9a9bc898ed7a417362877dc', $oauthContext->getCacheKey($context));
+        static::assertSame('227a7db4456daf05f54ab241d5913f07', $oauthContext->getCacheKey($context->withSandbox(false)));
     }
 
     public function testDebugInformationSensitive(): void

--- a/tests/unit/Gateway/CustomerGatewayTest.php
+++ b/tests/unit/Gateway/CustomerGatewayTest.php
@@ -39,12 +39,13 @@ class CustomerGatewayTest extends TestCase
 
     public function testGetMerchantIntegrations(): void
     {
-        $context = new ApiContext(new CredentialsOAuthContext('client-id', 'client-secret'), true, 'merchant-id', thirdParty: true);
+        $context = new ApiContext(new CredentialsOAuthContext('client-id', 'client-secret'), true, 'merchant-id', thirdParty: false);
         $body = (new MerchantIntegrations())->assign(['merchant_id' => 'merchant-id']);
 
         $this->gateways->setCachedToken($context);
         $this->client->addResponse(new Response(body: \json_encode($body, \JSON_THROW_ON_ERROR)));
 
+        $context = $context->withThirdParty(true); // for testing purposes
         $response = $this->gateways->customerGateway()->getMerchantIntegrations('partnerId', 'merchantId', $context);
         static::assertEquals($body, $response);
 
@@ -110,12 +111,13 @@ class CustomerGatewayTest extends TestCase
 
     public function testGetCredentials(): void
     {
-        $context = new ApiContext(new CredentialsOAuthContext('client-id', 'client-secret'), true, 'merchant-id', thirdParty: true);
+        $context = new ApiContext(new CredentialsOAuthContext('client-id', 'client-secret'), true, 'merchant-id', thirdParty: false);
         $body = ['client_id' => 'some-client-id', 'client_secret' => 'some-client-secret', 'payer_id' => 'some-payer-id'];
 
         $this->gateways->setCachedToken($context);
         $this->client->addResponse(new Response(body: \json_encode($body, \JSON_THROW_ON_ERROR)));
 
+        $context = $context->withThirdParty(true); // for testing purposes
         $response = $this->gateways->customerGateway()->getCredentials('partnerId', $context);
         static::assertSame($body['client_id'], $response->getClientId());
         static::assertSame($body['client_secret'], $response->getClientSecret());

--- a/tests/unit/Gateway/CustomerGatewayTest.php
+++ b/tests/unit/Gateway/CustomerGatewayTest.php
@@ -130,12 +130,13 @@ class CustomerGatewayTest extends TestCase
 
     public function testCreatePartnerReferral(): void
     {
-        $context = new ApiContext(new CredentialsOAuthContext('client-id', 'client-secret'), true, 'merchant-id', thirdParty: true);
+        $context = new ApiContext(new CredentialsOAuthContext('client-id', 'client-secret'), true, 'merchant-id', thirdParty: false);
         $body = (new Referral())->assign(['tracking_id' => 'tracking-id']);
 
         $this->gateways->setCachedToken($context);
         $this->client->addResponse(new Response(body: \json_encode($body, \JSON_THROW_ON_ERROR)));
 
+        $context = $context->withThirdParty(true); // for testing purposes
         $response = $this->gateways->customerGateway()->createPartnerReferral($body, $context);
         static::assertEquals($body, $response);
 


### PR DESCRIPTION
client token cache key need to respect merchant id