### PR TITLE
feat: add wallet domain management to CustomerGateway

### DIFF
--- a/src/Gateway/CustomerGateway.php
+++ b/src/Gateway/CustomerGateway.php
@@ -112,7 +112,10 @@ class CustomerGateway extends AbstractGateway
         );
     }
 
-    public function getWalletDomains(ApiContextInterface $context, int $page = 1, int $pageSize = 25): WalletDomains
+    /**
+     * Defaulting to page size 99 due to Apple Pay restrictions
+     */
+    public function getWalletDomains(ApiContextInterface $context, int $page = 1, int $pageSize = 99): WalletDomains
     {
         return $this->request(
             'GET',

--- a/src/Gateway/CustomerGateway.php
+++ b/src/Gateway/CustomerGateway.php
@@ -112,14 +112,16 @@ class CustomerGateway extends AbstractGateway
         );
     }
 
-    public function getWalletDomains(ApiContextInterface $context): WalletDomains
+    public function getWalletDomains(ApiContextInterface $context, int $page = 1, int $pageSize = 25): WalletDomains
     {
         return $this->request(
             'GET',
             self::GATEWAY_URL . '/wallet-domains',
             null,
             WalletDomains::class,
-            $context,
+            $context
+                ->withQueryParameter('page', (string) $page)
+                ->withQueryParameter('page_size', (string) $pageSize),
         );
     }
 

--- a/src/Gateway/CustomerGateway.php
+++ b/src/Gateway/CustomerGateway.php
@@ -13,6 +13,8 @@ use Shopware\PayPalSDK\Struct\V1\Disputes\Item as DisputeItem;
 use Shopware\PayPalSDK\Struct\V1\MerchantIntegrations;
 use Shopware\PayPalSDK\Struct\V1\MerchantIntegrations\Credentials;
 use Shopware\PayPalSDK\Struct\V1\MerchantTracking;
+use Shopware\PayPalSDK\Struct\V1\WalletDomain;
+use Shopware\PayPalSDK\Struct\V1\WalletDomains;
 use Shopware\PayPalSDK\Struct\V2\Referral;
 use Shopware\PayPalSDK\Struct\V3\ManagedAccount;
 
@@ -96,6 +98,39 @@ class CustomerGateway extends AbstractGateway
             null,
             ManagedAccount::class,
             $context->withThirdParty(false),
+        );
+    }
+
+    public function createWalletDomain(WalletDomain $walletDomain, ApiContextInterface $context): WalletDomain
+    {
+        return $this->request(
+            'POST',
+            self::GATEWAY_URL . '/wallet-domains',
+            $walletDomain,
+            WalletDomain::class,
+            $context,
+        );
+    }
+
+    public function getWalletDomains(ApiContextInterface $context): WalletDomains
+    {
+        return $this->request(
+            'GET',
+            self::GATEWAY_URL . '/wallet-domains',
+            null,
+            WalletDomains::class,
+            $context,
+        );
+    }
+
+    public function deleteWalletDomain(WalletDomain $walletDomain, ApiContextInterface $context): WalletDomain
+    {
+        return $this->request(
+            'POST',
+            self::GATEWAY_URL . '/unregister-wallet-domain',
+            $walletDomain,
+            WalletDomain::class,
+            $context,
         );
     }
 }

--- a/src/Struct/V1/WalletDomain.php
+++ b/src/Struct/V1/WalletDomain.php
@@ -10,6 +10,7 @@ namespace Shopware\PayPalSDK\Struct\V1;
 use OpenApi\Attributes as OA;
 use Shopware\PayPalSDK\Struct\Struct;
 use Shopware\PayPalSDK\Struct\V1\WalletDomain\Domain;
+use Shopware\PayPalSDK\Struct\V1\WalletDomain\Merchant;
 
 #[OA\Schema(schema: 'paypal_v1_wallet_domain')]
 class WalletDomain extends Struct
@@ -19,6 +20,9 @@ class WalletDomain extends Struct
 
     #[OA\Property(ref: Domain::class)]
     protected Domain $domain;
+
+    #[OA\Property(ref: Merchant::class, nullable: true)]
+    protected ?Merchant $merchant = null;
 
     #[OA\Property(type: 'string', nullable: true)]
     protected ?string $reason = null;
@@ -41,6 +45,16 @@ class WalletDomain extends Struct
     public function setDomain(Domain $domain): void
     {
         $this->domain = $domain;
+    }
+
+    public function getMerchant(): ?Merchant
+    {
+        return $this->merchant;
+    }
+
+    public function setMerchant(?Merchant $merchant): void
+    {
+        $this->merchant = $merchant;
     }
 
     public function getReason(): ?string

--- a/src/Struct/V1/WalletDomain.php
+++ b/src/Struct/V1/WalletDomain.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Shopware\PayPalSDK\Struct\V1;
+
+use OpenApi\Attributes as OA;
+use Shopware\PayPalSDK\Struct\Struct;
+use Shopware\PayPalSDK\Struct\V1\WalletDomain\Domain;
+
+#[OA\Schema(schema: 'paypal_v1_wallet_domain')]
+class WalletDomain extends Struct
+{
+    #[OA\Property(type: 'string')]
+    protected string $providerType;
+
+    #[OA\Property(ref: Domain::class)]
+    protected Domain $domain;
+
+    #[OA\Property(type: 'string', nullable: true)]
+    protected ?string $reason = null;
+
+    public function getProviderType(): string
+    {
+        return $this->providerType;
+    }
+
+    public function setProviderType(string $providerType): void
+    {
+        $this->providerType = $providerType;
+    }
+
+    public function getDomain(): Domain
+    {
+        return $this->domain;
+    }
+
+    public function setDomain(Domain $domain): void
+    {
+        $this->domain = $domain;
+    }
+
+    public function getReason(): ?string
+    {
+        return $this->reason;
+    }
+
+    public function setReason(?string $reason): void
+    {
+        $this->reason = $reason;
+    }
+}

--- a/src/Struct/V1/WalletDomain/Domain.php
+++ b/src/Struct/V1/WalletDomain/Domain.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Shopware\PayPalSDK\Struct\V1\WalletDomain;
+
+use OpenApi\Attributes as OA;
+use Shopware\PayPalSDK\Struct\Struct;
+
+#[OA\Schema(schema: 'paypal_v1_wallet_domain_domain')]
+class Domain extends Struct
+{
+    #[OA\Property(type: 'string')]
+    protected string $name;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+}

--- a/src/Struct/V1/WalletDomain/Merchant.php
+++ b/src/Struct/V1/WalletDomain/Merchant.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Shopware\PayPalSDK\Struct\V1\WalletDomain;
+
+use OpenApi\Attributes as OA;
+use Shopware\PayPalSDK\Struct\Struct;
+
+#[OA\Schema(schema: 'paypal_v1_wallet_domain_merchant')]
+class Merchant extends Struct
+{
+    #[OA\Property(type: 'string')]
+    protected string $accountId;
+
+    #[OA\Property(type: 'string', nullable: true)]
+    protected ?string $businessName = null;
+
+    #[OA\Property(type: 'string', nullable: true)]
+    protected ?string $url = null;
+
+    public function getAccountId(): string
+    {
+        return $this->accountId;
+    }
+
+    public function setAccountId(string $accountId): void
+    {
+        $this->accountId = $accountId;
+    }
+
+    public function getBusinessName(): ?string
+    {
+        return $this->businessName;
+    }
+
+    public function setBusinessName(?string $businessName): void
+    {
+        $this->businessName = $businessName;
+    }
+
+    public function getUrl(): ?string
+    {
+        return $this->url;
+    }
+
+    public function setUrl(?string $url): void
+    {
+        $this->url = $url;
+    }
+}

--- a/src/Struct/V1/WalletDomain/WalletDomainCollection.php
+++ b/src/Struct/V1/WalletDomain/WalletDomainCollection.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Shopware\PayPalSDK\Struct\V1\WalletDomain;
+
+use Shopware\PayPalSDK\Struct\Collection;
+use Shopware\PayPalSDK\Struct\V1\WalletDomain;
+
+/**
+ * @extends Collection<WalletDomain>
+ */
+class WalletDomainCollection extends Collection
+{
+    public static function getExpectedClass(): string
+    {
+        return WalletDomain::class;
+    }
+}

--- a/src/Struct/V1/WalletDomains.php
+++ b/src/Struct/V1/WalletDomains.php
@@ -9,13 +9,44 @@ namespace Shopware\PayPalSDK\Struct\V1;
 
 use OpenApi\Attributes as OA;
 use Shopware\PayPalSDK\Struct\Struct;
+use Shopware\PayPalSDK\Struct\V1\Common\Link;
+use Shopware\PayPalSDK\Struct\V1\Common\LinkCollection;
 use Shopware\PayPalSDK\Struct\V1\WalletDomain\WalletDomainCollection;
 
 #[OA\Schema(schema: 'paypal_v1_wallet_domains')]
 class WalletDomains extends Struct
 {
+    #[OA\Property(type: 'string', nullable: true)]
+    protected ?string $totalItems = null;
+
+    #[OA\Property(type: 'string', nullable: true)]
+    protected ?string $totalPages = null;
+
     #[OA\Property(type: 'array', items: new OA\Items(ref: WalletDomain::class))]
     protected WalletDomainCollection $walletDomains;
+
+    #[OA\Property(type: 'array', items: new OA\Items(ref: Link::class), nullable: true)]
+    protected ?LinkCollection $links = null;
+
+    public function getTotalItems(): ?string
+    {
+        return $this->totalItems;
+    }
+
+    public function setTotalItems(?string $totalItems): void
+    {
+        $this->totalItems = $totalItems;
+    }
+
+    public function getTotalPages(): ?string
+    {
+        return $this->totalPages;
+    }
+
+    public function setTotalPages(?string $totalPages): void
+    {
+        $this->totalPages = $totalPages;
+    }
 
     public function getWalletDomains(): WalletDomainCollection
     {
@@ -25,5 +56,15 @@ class WalletDomains extends Struct
     public function setWalletDomains(WalletDomainCollection $walletDomains): void
     {
         $this->walletDomains = $walletDomains;
+    }
+
+    public function getLinks(): ?LinkCollection
+    {
+        return $this->links;
+    }
+
+    public function setLinks(?LinkCollection $links): void
+    {
+        $this->links = $links;
     }
 }

--- a/src/Struct/V1/WalletDomains.php
+++ b/src/Struct/V1/WalletDomains.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Shopware\PayPalSDK\Struct\V1;
+
+use OpenApi\Attributes as OA;
+use Shopware\PayPalSDK\Struct\Struct;
+use Shopware\PayPalSDK\Struct\V1\WalletDomain\WalletDomainCollection;
+
+#[OA\Schema(schema: 'paypal_v1_wallet_domains')]
+class WalletDomains extends Struct
+{
+    #[OA\Property(type: 'array', items: new OA\Items(ref: WalletDomain::class))]
+    protected WalletDomainCollection $walletDomains;
+
+    public function getWalletDomains(): WalletDomainCollection
+    {
+        return $this->walletDomains;
+    }
+
+    public function setWalletDomains(WalletDomainCollection $walletDomains): void
+    {
+        $this->walletDomains = $walletDomains;
+    }
+}

--- a/tests/unit/Gateway/CustomerGatewayTest.php
+++ b/tests/unit/Gateway/CustomerGatewayTest.php
@@ -172,7 +172,7 @@ class CustomerGatewayTest extends TestCase
     public function testCreateWalletDomain(): void
     {
         $context = new ApiContext(new CredentialsOAuthContext('client-id', 'client-secret'), true, 'merchant-id');
-        $body = (new WalletDomain())->assign(['provider_type' => 'APPLE_PAY', 'domain' => ['name' => 'example.com']]);
+        $body = (new WalletDomain())->assign(['provider_type' => 'APPLE_PAY', 'domain' => ['name' => 'example.com'], 'merchant' => ['account_id' => 'merchant-id', 'business_name' => 'Test Store', 'url' => 'http://example.com']]);
 
         $this->gateways->setCachedToken($context);
         $this->client->addResponse(new Response(body: \json_encode($body, \JSON_THROW_ON_ERROR)));
@@ -190,7 +190,11 @@ class CustomerGatewayTest extends TestCase
     public function testGetWalletDomains(): void
     {
         $context = new ApiContext(new CredentialsOAuthContext('client-id', 'client-secret'), true, 'merchant-id');
-        $body = (new WalletDomains())->assign(['wallet_domains' => [['provider_type' => 'APPLE_PAY', 'domain' => ['name' => 'example.com']]]]);
+        $body = (new WalletDomains())->assign([
+            'total_items' => '1',
+            'total_pages' => '1',
+            'wallet_domains' => [['provider_type' => 'APPLE_PAY', 'domain' => ['name' => 'example.com'], 'merchant' => ['account_id' => 'merchant-id']]],
+        ]);
 
         $this->gateways->setCachedToken($context);
         $this->client->addResponse(new Response(body: \json_encode($body, \JSON_THROW_ON_ERROR)));
@@ -202,12 +206,35 @@ class CustomerGatewayTest extends TestCase
         static::assertNotNull($last);
         static::assertSame('GET', $last->getRequest()->getMethod());
         static::assertSame('/v1/customer/wallet-domains', $last->getRequest()->getUri()->getPath());
+        static::assertSame('page=1&page_size=25', $last->getRequest()->getUri()->getQuery());
+    }
+
+    public function testGetWalletDomainsWithPagination(): void
+    {
+        $context = new ApiContext(new CredentialsOAuthContext('client-id', 'client-secret'), true, 'merchant-id');
+        $body = (new WalletDomains())->assign([
+            'total_items' => '50',
+            'total_pages' => '5',
+            'wallet_domains' => [['provider_type' => 'APPLE_PAY', 'domain' => ['name' => 'example.com']]],
+        ]);
+
+        $this->gateways->setCachedToken($context);
+        $this->client->addResponse(new Response(body: \json_encode($body, \JSON_THROW_ON_ERROR)));
+
+        $response = $this->gateways->customerGateway()->getWalletDomains($context, 3, 10);
+        static::assertEquals($body, $response);
+
+        $last = $this->client->getLast();
+        static::assertNotNull($last);
+        static::assertSame('GET', $last->getRequest()->getMethod());
+        static::assertSame('/v1/customer/wallet-domains', $last->getRequest()->getUri()->getPath());
+        static::assertSame('page=3&page_size=10', $last->getRequest()->getUri()->getQuery());
     }
 
     public function testDeleteWalletDomain(): void
     {
         $context = new ApiContext(new CredentialsOAuthContext('client-id', 'client-secret'), true, 'merchant-id');
-        $body = (new WalletDomain())->assign(['provider_type' => 'APPLE_PAY', 'domain' => ['name' => 'example.com'], 'reason' => 'Merchant requested to deregister domain']);
+        $body = (new WalletDomain())->assign(['provider_type' => 'APPLE_PAY', 'domain' => ['name' => 'example.com'], 'merchant' => ['account_id' => 'merchant-id'], 'reason' => 'Merchant requested to deregister domain']);
 
         $this->gateways->setCachedToken($context);
         $this->client->addResponse(new Response(body: \json_encode($body, \JSON_THROW_ON_ERROR)));

--- a/tests/unit/Gateway/CustomerGatewayTest.php
+++ b/tests/unit/Gateway/CustomerGatewayTest.php
@@ -17,6 +17,8 @@ use Shopware\PayPalSDK\Struct\V1\Disputes;
 use Shopware\PayPalSDK\Struct\V1\Disputes\Item;
 use Shopware\PayPalSDK\Struct\V1\MerchantIntegrations;
 use Shopware\PayPalSDK\Struct\V1\MerchantTracking;
+use Shopware\PayPalSDK\Struct\V1\WalletDomain;
+use Shopware\PayPalSDK\Struct\V1\WalletDomains;
 use Shopware\PayPalSDK\Struct\V2\Referral;
 use Shopware\PayPalSDK\Test\Gateway\TestGateways;
 use Shopware\PayPalSDK\Test\Request\TestClient;
@@ -165,5 +167,58 @@ class CustomerGatewayTest extends TestCase
         static::assertNotNull($last);
         static::assertSame('GET', $last->getRequest()->getMethod());
         static::assertSame('/v3/customer/managed-accounts/some-account-id', $last->getRequest()->getUri()->getPath());
+    }
+
+    public function testCreateWalletDomain(): void
+    {
+        $context = new ApiContext(new CredentialsOAuthContext('client-id', 'client-secret'), true, 'merchant-id');
+        $body = (new WalletDomain())->assign(['provider_type' => 'APPLE_PAY', 'domain' => ['name' => 'example.com']]);
+
+        $this->gateways->setCachedToken($context);
+        $this->client->addResponse(new Response(body: \json_encode($body, \JSON_THROW_ON_ERROR)));
+
+        $response = $this->gateways->customerGateway()->createWalletDomain($body, $context);
+        static::assertEquals($body, $response);
+
+        $last = $this->client->getLast();
+        static::assertNotNull($last);
+        static::assertSame('POST', $last->getRequest()->getMethod());
+        static::assertSame('/v1/customer/wallet-domains', $last->getRequest()->getUri()->getPath());
+        static::assertSame(\json_encode($body), (string) $last->getRequest()->getBody());
+    }
+
+    public function testGetWalletDomains(): void
+    {
+        $context = new ApiContext(new CredentialsOAuthContext('client-id', 'client-secret'), true, 'merchant-id');
+        $body = (new WalletDomains())->assign(['wallet_domains' => [['provider_type' => 'APPLE_PAY', 'domain' => ['name' => 'example.com']]]]);
+
+        $this->gateways->setCachedToken($context);
+        $this->client->addResponse(new Response(body: \json_encode($body, \JSON_THROW_ON_ERROR)));
+
+        $response = $this->gateways->customerGateway()->getWalletDomains($context);
+        static::assertEquals($body, $response);
+
+        $last = $this->client->getLast();
+        static::assertNotNull($last);
+        static::assertSame('GET', $last->getRequest()->getMethod());
+        static::assertSame('/v1/customer/wallet-domains', $last->getRequest()->getUri()->getPath());
+    }
+
+    public function testDeleteWalletDomain(): void
+    {
+        $context = new ApiContext(new CredentialsOAuthContext('client-id', 'client-secret'), true, 'merchant-id');
+        $body = (new WalletDomain())->assign(['provider_type' => 'APPLE_PAY', 'domain' => ['name' => 'example.com'], 'reason' => 'Merchant requested to deregister domain']);
+
+        $this->gateways->setCachedToken($context);
+        $this->client->addResponse(new Response(body: \json_encode($body, \JSON_THROW_ON_ERROR)));
+
+        $response = $this->gateways->customerGateway()->deleteWalletDomain($body, $context);
+        static::assertEquals($body, $response);
+
+        $last = $this->client->getLast();
+        static::assertNotNull($last);
+        static::assertSame('POST', $last->getRequest()->getMethod());
+        static::assertSame('/v1/customer/unregister-wallet-domain', $last->getRequest()->getUri()->getPath());
+        static::assertSame(\json_encode($body), (string) $last->getRequest()->getBody());
     }
 }

--- a/tests/unit/Gateway/CustomerGatewayTest.php
+++ b/tests/unit/Gateway/CustomerGatewayTest.php
@@ -206,7 +206,7 @@ class CustomerGatewayTest extends TestCase
         static::assertNotNull($last);
         static::assertSame('GET', $last->getRequest()->getMethod());
         static::assertSame('/v1/customer/wallet-domains', $last->getRequest()->getUri()->getPath());
-        static::assertSame('page=1&page_size=25', $last->getRequest()->getUri()->getQuery());
+        static::assertSame('page=1&page_size=99', $last->getRequest()->getUri()->getQuery());
     }
 
     public function testGetWalletDomainsWithPagination(): void


### PR DESCRIPTION
## Summary
- Add `createWalletDomain()`, `getWalletDomains()`, and `deleteWalletDomain()` methods to `CustomerGateway`
- Introduce `WalletDomain` struct (shared for create/delete), nested `Domain` struct, `WalletDomainCollection`, and `WalletDomains` list response wrapper
- Endpoints: `POST /v1/customer/wallet-domains`, `GET /v1/customer/wallet-domains`, `POST /v1/customer/unregister-wallet-domain`

## Context
PayPal provides API endpoints for managing Apple Pay wallet domains (register, list, deregister). This adds SDK support for those endpoints as described in the [Apple Pay integration docs](https://developer.paypal.com/docs/multiparty/checkout/apm/apple-pay/#register-your-sandbox-domain).

The `WalletDomain` struct is shared between create and delete — the `reason` field is nullable and only populated for deregistration.

## Test plan
- [x] Unit tests for all three new gateway methods pass
- [x] OpenAPI schema integration tests pass
- [ ] Verify against PayPal sandbox with real credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)