### PR TITLE
fix: revert collection array filter

### DIFF
--- a/src/Struct/Collection.php
+++ b/src/Struct/Collection.php
@@ -178,7 +178,7 @@ abstract class Collection implements \IteratorAggregate, \Countable, \JsonSerial
      */
     public function jsonSerialize(): array
     {
-        return \array_values(\array_filter($this->map(static fn (Struct $e): array => $e->jsonSerialize())));
+        return \array_values($this->map(static fn (Struct $e): array => $e->jsonSerialize()));
     }
 
     /**


### PR DESCRIPTION
This came up during the merge of agentic commerce structs and co.

As this ones rather breaking, we will put this back and test any regression for agentic commerce, however this should be fixed for payments and the plugin for now.