### PR TITLE
feat: add app switch structs

### DIFF
--- a/src/Struct/V2/Order/PaymentSource/Common/AppSwitchContext.php
+++ b/src/Struct/V2/Order/PaymentSource/Common/AppSwitchContext.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Common;
+
+use OpenApi\Attributes as OA;
+use Shopware\PayPalSDK\Struct\Struct;
+use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Common\AppSwitchContext\MobileWebContext;
+use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Common\AppSwitchContext\NativeAppContext;
+
+#[OA\Schema(schema: 'paypal_v2_order_payment_source_common_app_switch_context')]
+class AppSwitchContext extends Struct
+{
+    #[OA\Property(ref: NativeAppContext::class, nullable: true)]
+    protected ?NativeAppContext $nativeApp = null;
+
+    #[OA\Property(ref: MobileWebContext::class, nullable: true)]
+    protected ?MobileWebContext $mobileWeb = null;
+
+    public function getNativeApp(): ?NativeAppContext
+    {
+        return $this->nativeApp;
+    }
+
+    public function setNativeApp(?NativeAppContext $nativeApp): void
+    {
+        $this->nativeApp = $nativeApp;
+    }
+
+    public function getMobileWeb(): ?MobileWebContext
+    {
+        return $this->mobileWeb;
+    }
+
+    public function setMobileWeb(?MobileWebContext $mobileWeb): void
+    {
+        $this->mobileWeb = $mobileWeb;
+    }
+}

--- a/src/Struct/V2/Order/PaymentSource/Common/AppSwitchContext/MobileWebContext.php
+++ b/src/Struct/V2/Order/PaymentSource/Common/AppSwitchContext/MobileWebContext.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Common\AppSwitchContext;
+
+use OpenApi\Attributes as OA;
+use Shopware\PayPalSDK\Struct\Struct;
+
+#[OA\Schema(schema: 'paypal_v2_order_payment_source_common_app_switch_context_mobile_web_context')]
+class MobileWebContext extends Struct
+{
+    public const RETURN_FLOW_AUTO = 'AUTO';
+    public const RETURN_FLOW_MANUAL = 'MANUAL';
+    public const RETURN_FLOWS = [
+        self::RETURN_FLOW_AUTO,
+        self::RETURN_FLOW_MANUAL,
+    ];
+
+    #[OA\Property(type: 'string', default: self::RETURN_FLOW_AUTO, enum: self::RETURN_FLOWS)]
+    protected string $returnFlow = self::RETURN_FLOW_AUTO;
+
+    #[OA\Property(type: 'string', maxLength: 512, minLength: 1)]
+    protected string $buyerUserAgent;
+
+    public function getReturnFlow(): string
+    {
+        return $this->returnFlow;
+    }
+
+    public function setReturnFlow(string $returnFlow): void
+    {
+        $this->returnFlow = $returnFlow;
+    }
+
+    public function getBuyerUserAgent(): string
+    {
+        return $this->buyerUserAgent;
+    }
+
+    public function setBuyerUserAgent(string $buyerUserAgent): void
+    {
+        $this->buyerUserAgent = $buyerUserAgent;
+    }
+}

--- a/src/Struct/V2/Order/PaymentSource/Common/AppSwitchContext/NativeAppContext.php
+++ b/src/Struct/V2/Order/PaymentSource/Common/AppSwitchContext/NativeAppContext.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Common\AppSwitchContext;
+
+use OpenApi\Attributes as OA;
+use Shopware\PayPalSDK\Struct\Struct;
+
+#[OA\Schema(schema: 'paypal_v2_order_payment_source_common_app_switch_context_native_app_context')]
+class NativeAppContext extends Struct
+{
+    public const OS_TYPE_ANDROID = 'ANDROID';
+    public const OS_TYPE_IOS = 'IOS';
+    public const OS_TYPE_OTHER = 'OTHER';
+    public const OS_TYPES = [
+        self::OS_TYPE_ANDROID,
+        self::OS_TYPE_IOS,
+        self::OS_TYPE_OTHER,
+    ];
+
+    #[OA\Property(type: 'string', enum: self::OS_TYPES)]
+    protected string $osType;
+
+    #[OA\Property(type: 'string', maxLength: 64, minLength: 1)]
+    protected string $osVersion;
+
+    public function getOsType(): string
+    {
+        return $this->osType;
+    }
+
+    public function setOsType(string $osType): void
+    {
+        $this->osType = $osType;
+    }
+
+    public function getOsVersion(): string
+    {
+        return $this->osVersion;
+    }
+
+    public function setOsVersion(string $osVersion): void
+    {
+        $this->osVersion = $osVersion;
+    }
+}

--- a/src/Struct/V2/Order/PaymentSource/Common/ExperienceContext.php
+++ b/src/Struct/V2/Order/PaymentSource/Common/ExperienceContext.php
@@ -79,6 +79,9 @@ class ExperienceContext extends Struct
     #[OA\Property(ref: OrderUpdateCallbackConfig::class)]
     protected ?OrderUpdateCallbackConfig $orderUpdateCallbackConfig = null;
 
+    #[OA\Property(ref: AppSwitchContext::class, nullable: true)]
+    protected ?AppSwitchContext $appSwitchContext = null;
+
     public function getLocale(): string
     {
         return $this->locale;
@@ -193,6 +196,16 @@ class ExperienceContext extends Struct
     public function setOrderUpdateCallbackConfig(?OrderUpdateCallbackConfig $orderUpdateCallbackConfig): void
     {
         $this->orderUpdateCallbackConfig = $orderUpdateCallbackConfig;
+    }
+
+    public function getAppSwitchContext(): ?AppSwitchContext
+    {
+        return $this->appSwitchContext;
+    }
+
+    public function setAppSwitchContext(?AppSwitchContext $appSwitchContext): void
+    {
+        $this->appSwitchContext = $appSwitchContext;
     }
 
     public function getAcquiringChannel(): string

--- a/tests/unit/Struct/V2/PaymentSourceTest.php
+++ b/tests/unit/Struct/V2/PaymentSourceTest.php
@@ -12,6 +12,9 @@ use PHPUnit\Framework\TestCase;
 use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource;
 use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Afterpay;
 use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Bank\SepaDebit;
+use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Common\AppSwitchContext;
+use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Common\AppSwitchContext\MobileWebContext;
+use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Common\AppSwitchContext\NativeAppContext;
 use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Common\ExperienceContext;
 use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Klarna;
 use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Klarna\AuthorizationContext;
@@ -159,6 +162,59 @@ class PaymentSourceTest extends TestCase
         static::assertSame('https://example.com/return', $experienceContext->getReturnUrl());
         static::assertSame('https://example.com/cancel', $experienceContext->getCancelUrl());
         static::assertSame(ExperienceContext::ACQUIRING_CHANNEL_ECOMMERCE, $experienceContext->getAcquiringChannel());
+    }
+
+    public function testPaypalPaymentSourceWithAppSwitchContext(): void
+    {
+        $paymentSource = (new PaymentSource())->assign([
+            'paypal' => [
+                'experience_context' => [
+                    'return_url' => 'https://example.com/merchant-app',
+                    'cancel_url' => 'https://example.com/merchant-app',
+                    'user_action' => ExperienceContext::USER_ACTION_PAY_NOW,
+                    'app_switch_context' => [
+                        'native_app' => [
+                            'os_type' => NativeAppContext::OS_TYPE_IOS,
+                            'os_version' => '17.5',
+                        ],
+                        'mobile_web' => [
+                            'return_flow' => MobileWebContext::RETURN_FLOW_AUTO,
+                            'buyer_user_agent' => 'Mozilla/5.0',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $paypal = $paymentSource->getPaypal();
+        static::assertNotNull($paypal);
+
+        $experienceContext = $paypal->getExperienceContext();
+        $appSwitchContext = $experienceContext->getAppSwitchContext();
+        static::assertInstanceOf(AppSwitchContext::class, $appSwitchContext);
+
+        $nativeApp = $appSwitchContext->getNativeApp();
+        static::assertInstanceOf(NativeAppContext::class, $nativeApp);
+        static::assertSame(NativeAppContext::OS_TYPE_IOS, $nativeApp->getOsType());
+        static::assertSame('17.5', $nativeApp->getOsVersion());
+
+        $mobileWeb = $appSwitchContext->getMobileWeb();
+        static::assertInstanceOf(MobileWebContext::class, $mobileWeb);
+        static::assertSame(MobileWebContext::RETURN_FLOW_AUTO, $mobileWeb->getReturnFlow());
+        static::assertSame('Mozilla/5.0', $mobileWeb->getBuyerUserAgent());
+
+        $experienceContextPayload = $experienceContext->jsonSerialize();
+
+        static::assertSame([
+            'native_app' => [
+                'os_type' => NativeAppContext::OS_TYPE_IOS,
+                'os_version' => '17.5',
+            ],
+            'mobile_web' => [
+                'return_flow' => MobileWebContext::RETURN_FLOW_AUTO,
+                'buyer_user_agent' => 'Mozilla/5.0',
+            ],
+        ], $experienceContextPayload['app_switch_context']);
     }
 
     public function testSwishPaymentSource(): void


### PR DESCRIPTION
## Summary

Adds Orders v2 app-switch support to the SDK struct layer by exposing `app_switch_context` on the shared payment-source experience context.

The new struct tree covers PayPal's native-app and mobile-web app-switch payloads, including OS type/version, return flow, and buyer user-agent fields. A unit test verifies assignment and snake_case serialization through `payment_source.paypal.experience_context`.