### PR TITLE
fix: resolve agentic commerce openapi refs

### DIFF
--- a/src/Struct/AgenticCommerce/V1/AgentErrorDetail.php
+++ b/src/Struct/AgenticCommerce/V1/AgentErrorDetail.php
@@ -7,17 +7,25 @@
 
 namespace Shopware\PayPalSDK\Struct\AgenticCommerce\V1;
 
+use OpenApi\Attributes as OA;
 use Shopware\PayPalSDK\Struct\Struct;
 
 /**
  * @experimental
  */
+#[OA\Schema(
+    schema: 'paypal_agentic_commerce_v1_agent_error_detail',
+    required: ['field', 'issue', 'description']
+)]
 class AgentErrorDetail extends Struct
 {
+    #[OA\Property(type: 'string')]
     protected string $field;
 
+    #[OA\Property(type: 'string')]
     protected string $issue;
 
+    #[OA\Property(type: 'string')]
     protected string $description;
 
     public function getField(): string

--- a/src/Struct/AgenticCommerce/V1/BillingAddress.php
+++ b/src/Struct/AgenticCommerce/V1/BillingAddress.php
@@ -7,6 +7,8 @@
 
 namespace Shopware\PayPalSDK\Struct\AgenticCommerce\V1;
 
+use OpenApi\Attributes as OA;
+
 /**
  * Billing address for merchant business purposes, obtained from customer's PayPal profile. Similar to shipping addresses, billing addresses can be retrieved from customer's default address information stored in their PayPal account.
  *
@@ -42,6 +44,10 @@ namespace Shopware\PayPalSDK\Struct\AgenticCommerce\V1;
  *
  * @experimental
  */
+#[OA\Schema(
+    schema: 'paypal_agentic_commerce_v1_billing_address',
+    allOf: [new OA\Schema(ref: Address::class)]
+)]
 class BillingAddress extends Address
 {
 }

--- a/src/Struct/AgenticCommerce/V1/CartItem.php
+++ b/src/Struct/AgenticCommerce/V1/CartItem.php
@@ -8,7 +8,9 @@
 namespace Shopware\PayPalSDK\Struct\AgenticCommerce\V1;
 
 use OpenApi\Attributes as OA;
+use Shopware\PayPalSDK\Struct\AgenticCommerce\V1\Referral\CustomOption;
 use Shopware\PayPalSDK\Struct\AgenticCommerce\V1\Referral\CustomOptionCollection;
+use Shopware\PayPalSDK\Struct\AgenticCommerce\V1\Referral\SelectedAttribute;
 use Shopware\PayPalSDK\Struct\AgenticCommerce\V1\Referral\SelectedAttributeCollection;
 use Shopware\PayPalSDK\Struct\Struct;
 
@@ -66,13 +68,13 @@ class CartItem extends Struct
     #[OA\Property(ref: Money::class)]
     protected ?Money $price = null;
 
-    #[OA\Property(ref: SelectedAttributeCollection::class)]
+    #[OA\Property(type: 'array', items: new OA\Items(ref: SelectedAttribute::class))]
     protected SelectedAttributeCollection $selectedAttributes;
 
     #[OA\Property(ref: GiftOptions::class)]
     protected ?GiftOptions $giftOptions = null;
 
-    #[OA\Property(ref: CustomOptionCollection::class)]
+    #[OA\Property(type: 'array', items: new OA\Items(ref: CustomOption::class))]
     protected CustomOptionCollection $customOptions;
 
     public function getItemId(): ?string

--- a/src/Struct/AgenticCommerce/V1/Context/BusinessRuleErrorContext.php
+++ b/src/Struct/AgenticCommerce/V1/Context/BusinessRuleErrorContext.php
@@ -8,6 +8,7 @@
 namespace Shopware\PayPalSDK\Struct\AgenticCommerce\V1\Context;
 
 use OpenApi\Attributes as OA;
+use Shopware\PayPalSDK\Struct\AgenticCommerce\V1\Referral\BusinessHour;
 use Shopware\PayPalSDK\Struct\AgenticCommerce\V1\Referral\BusinessHourCollection;
 
 /**
@@ -145,7 +146,7 @@ class BusinessRuleErrorContext extends AbstractContext
     /**
      * Store business hours
      */
-    #[OA\Property(ref: BusinessHourCollection::class)]
+    #[OA\Property(type: 'array', items: new OA\Items(ref: BusinessHour::class))]
     protected BusinessHourCollection $businessHours;
 
     /**

--- a/src/Struct/AgenticCommerce/V1/Context/PricingErrorContext.php
+++ b/src/Struct/AgenticCommerce/V1/Context/PricingErrorContext.php
@@ -8,6 +8,7 @@
 namespace Shopware\PayPalSDK\Struct\AgenticCommerce\V1\Context;
 
 use OpenApi\Attributes as OA;
+use Shopware\PayPalSDK\Struct\AgenticCommerce\V1\Referral\MixedItem;
 use Shopware\PayPalSDK\Struct\AgenticCommerce\V1\Referral\MixedItemCollection;
 
 /**
@@ -168,7 +169,7 @@ class PricingErrorContext extends AbstractContext
     /**
      * Items with different currencies
      */
-    #[OA\Property(ref: MixedItemCollection::class)]
+    #[OA\Property(type: 'array', items: new OA\Items(ref: MixedItem::class))]
     protected MixedItemCollection $mixedItems;
 
     public function getItemId(): ?string

--- a/src/Struct/AgenticCommerce/V1/Context/ShippingErrorContext.php
+++ b/src/Struct/AgenticCommerce/V1/Context/ShippingErrorContext.php
@@ -58,7 +58,7 @@ class ShippingErrorContext extends AbstractContext
     /**
      * Suggested address corrections
      */
-    #[OA\Property(ref: SuggestedCorrectionCollection::class)]
+    #[OA\Property(type: 'array', items: new OA\Items(ref: SuggestedCorrection::class))]
     protected SuggestedCorrectionCollection $suggestedCorrections;
 
     /**

--- a/src/Struct/AgenticCommerce/V1/Error.php
+++ b/src/Struct/AgenticCommerce/V1/Error.php
@@ -40,7 +40,7 @@ class Error extends Struct
     /**
      * Detailed error information
      */
-    #[OA\Property(ref: AgentErrorDetailCollection::class)]
+    #[OA\Property(type: 'array', items: new OA\Items(ref: AgentErrorDetail::class))]
     protected AgentErrorDetailCollection $details;
 
     public function getName(): string

--- a/src/Struct/AgenticCommerce/V1/PayPalCart.php
+++ b/src/Struct/AgenticCommerce/V1/PayPalCart.php
@@ -78,7 +78,7 @@ class PayPalCart extends Struct
     /**
      * List of issues preventing checkout (empty = ready)
      */
-    #[OA\Property(ref: ValidationIssueCollection::class)]
+    #[OA\Property(type: 'array', items: new OA\Items(ref: ValidationIssue::class))]
     protected ValidationIssueCollection $validationIssues;
 
     #[OA\Property(ref: CartTotals::class)]
@@ -87,25 +87,25 @@ class PayPalCart extends Struct
     /**
      * Successfully applied coupons (server-calculated)
      */
-    #[OA\Property(ref: AppliedCouponCollection::class)]
+    #[OA\Property(type: 'array', items: new OA\Items(ref: AppliedCoupon::class))]
     protected ?AppliedCouponCollection $appliedCoupons = null;
 
     /**
      * Available shipping methods with selection state
      */
-    #[OA\Property(ref: ShippingOptionCollection::class)]
+    #[OA\Property(type: 'array', items: new OA\Items(ref: ShippingOption::class))]
     protected ?ShippingOptionCollection $availableShippingOptions = null;
 
     /**
      * HATEOAS navigation links for cart operations
      */
-    #[OA\Property(ref: LinkCollection::class)]
+    #[OA\Property(type: 'array', items: new OA\Items(ref: Link::class))]
     protected ?LinkCollection $links = null;
 
     /**
      * Products in the cart
      */
-    #[OA\Property(ref: CartItemCollection::class)]
+    #[OA\Property(type: 'array', items: new OA\Items(ref: CartItem::class))]
     protected CartItemCollection $items;
 
     #[OA\Property(ref: Customer::class)]
@@ -123,13 +123,13 @@ class PayPalCart extends Struct
     /**
      * Custom checkout fields (age verification, etc.)
      */
-    #[OA\Property(ref: CheckoutFieldCollection::class)]
+    #[OA\Property(type: 'array', items: new OA\Items(ref: CheckoutField::class))]
     protected ?CheckoutFieldCollection $checkoutFields = null;
 
     /**
      * Discount coupons to apply or remove from cart
      */
-    #[OA\Property(ref: CouponCollection::class)]
+    #[OA\Property(type: 'array', items: new OA\Items(ref: Coupon::class))]
     protected CouponCollection $coupons;
 
     #[OA\Property(ref: GeoCoordinates::class)]

--- a/src/Struct/AgenticCommerce/V1/ShippingAddress.php
+++ b/src/Struct/AgenticCommerce/V1/ShippingAddress.php
@@ -7,9 +7,15 @@
 
 namespace Shopware\PayPalSDK\Struct\AgenticCommerce\V1;
 
+use OpenApi\Attributes as OA;
+
 /**
  * @experimental
  */
+#[OA\Schema(
+    schema: 'paypal_agentic_commerce_v1_shipping_address',
+    allOf: [new OA\Schema(ref: Address::class)]
+)]
 class ShippingAddress extends Address
 {
 }

--- a/src/Struct/AgenticCommerce/V1/ValidationIssue.php
+++ b/src/Struct/AgenticCommerce/V1/ValidationIssue.php
@@ -106,7 +106,7 @@ class ValidationIssue extends Struct
     /**
      * Available actions to resolve this issue
      */
-    #[OA\Property(ref: ResolutionOptionCollection::class)]
+    #[OA\Property(type: 'array', items: new OA\Items(ref: ResolutionOption::class))]
     protected ResolutionOptionCollection $resolutionOptions;
 
     public function getCode(): string


### PR DESCRIPTION
## What changed

Fixes Agentic Commerce OpenAPI annotations so generated schemas do not contain raw PHP class-name refs.

- collection properties now emit `type: array` with item refs instead of refs to SDK collection classes
- `ShippingAddress` and `BillingAddress` now have explicit schemas based on the shared address schema
- `AgentErrorDetail` now has an explicit schema and string property metadata

## Why

Consumers that generate TypeScript from the SDK OpenAPI metadata fail when `$ref` points to PHP class names such as `Shopware\PayPalSDK\Struct\AgenticCommerce\V1\CouponCollection` instead of `#/components/schemas/...`.

