### PR TITLE
feat: added rate limit exception

### DIFF
--- a/src/Exception/ExceptionFactory.php
+++ b/src/Exception/ExceptionFactory.php
@@ -38,14 +38,15 @@ class ExceptionFactory
         }
 
         if ($error->getName() && $error->getMessage()) {
-            if ($error->getName() === ApiException::CODE_RATE_LIMIT_REACHED) {
-                return RetryAfterApiException::fromErrorResponse(
+            if ($response->getStatusCode() === 429) {
+                return new RetryAfterApiException(
                     $error->getName(),
                     $error->getMessage(),
                     $response,
                     $error->getDebugId() ?? '',
                     $error->getLinks(),
                     $error->getDetails(),
+                    $response->getHeaderLine('Retry-After') ?: null,
                 );
             }
 

--- a/src/Exception/ExceptionFactory.php
+++ b/src/Exception/ExceptionFactory.php
@@ -38,6 +38,17 @@ class ExceptionFactory
         }
 
         if ($error->getName() && $error->getMessage()) {
+            if ($error->getName() === ApiException::CODE_RATE_LIMIT_REACHED) {
+                return RetryAfterApiException::fromErrorResponse(
+                    $error->getName(),
+                    $error->getMessage(),
+                    $response,
+                    $error->getDebugId() ?? '',
+                    $error->getLinks(),
+                    $error->getDetails(),
+                );
+            }
+
             return new ErrorApiException(
                 $error->getName(),
                 $error->getMessage(),

--- a/src/Exception/RetryAfterApiException.php
+++ b/src/Exception/RetryAfterApiException.php
@@ -16,7 +16,7 @@ use Shopware\PayPalSDK\Struct\V1\Common\LinkCollection;
  */
 class RetryAfterApiException extends ErrorApiException
 {
-    private const MILLISECONDS_PER_SECOND = 1000;
+    private readonly ?\DateTimeImmutable $retryAt;
 
     public function __construct(
         string $errorCode,
@@ -25,9 +25,16 @@ class RetryAfterApiException extends ErrorApiException
         string $debugId,
         ?LinkCollection $links = null,
         ?DetailCollection $details = null,
-        private readonly ?int $retryDelay = null,
+        ?string $retryAfter = null,
     ) {
         parent::__construct($errorCode, $reason, $response, $debugId, $links, $details);
+
+        $this->retryAt = self::parseRetryAt($retryAfter);
+    }
+
+    public function getRetryAt(): ?\DateTimeImmutable
+    {
+        return $this->retryAt;
     }
 
     /**
@@ -35,47 +42,38 @@ class RetryAfterApiException extends ErrorApiException
      */
     public function getRetryDelay(): ?int
     {
-        return $this->retryDelay;
+        if ($this->retryAt === null) {
+            return null;
+        }
+
+        $retryDelay = ($this->retryAt->getTimestamp() - \time()) * 1000;
+
+        return $retryDelay > 0 ? $retryDelay : null;
     }
 
-    public static function fromErrorResponse(
-        string $errorCode,
-        string $reason,
-        ResponseInterface $response,
-        string $debugId,
-        ?LinkCollection $links = null,
-        ?DetailCollection $details = null,
-    ): self {
-        return new self(
-            $errorCode,
-            $reason,
-            $response,
-            $debugId,
-            $links,
-            $details,
-            self::parseRetryDelay($response->getHeaderLine('Retry-After') ?: null),
-        );
-    }
-
-    private static function parseRetryDelay(?string $retryAfter): ?int
+    private static function parseRetryAt(?string $retryAfter): ?\DateTimeImmutable
     {
         if ($retryAfter === null || ($retryAfter = \trim($retryAfter)) === '') {
             return null;
         }
 
         if (\ctype_digit($retryAfter)) {
-            $retryDelay = (int) $retryAfter * self::MILLISECONDS_PER_SECOND;
+            $seconds = (int) $retryAfter;
 
-            return $retryDelay > 0 ? $retryDelay : null;
+            if ($seconds <= 0) {
+                return null;
+            }
+
+            $retryAt = (new \DateTimeImmutable())->modify(\sprintf('+%d seconds', $seconds));
+
+            return $retryAt ?: null;
         }
 
         $retryAt = \strtotime($retryAfter);
-        if ($retryAt === false) {
+        if ($retryAt === false || $retryAt <= \time()) {
             return null;
         }
 
-        $retryDelay = ($retryAt - \time()) * self::MILLISECONDS_PER_SECOND;
-
-        return $retryDelay > 0 ? $retryDelay : null;
+        return (new \DateTimeImmutable())->setTimestamp($retryAt);
     }
 }

--- a/src/Exception/RetryAfterApiException.php
+++ b/src/Exception/RetryAfterApiException.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Shopware\PayPalSDK\Exception;
+
+use Psr\Http\Message\ResponseInterface;
+use Shopware\PayPalSDK\Struct\Error\DetailCollection;
+use Shopware\PayPalSDK\Struct\V1\Common\LinkCollection;
+
+/**
+ * Exception used for recoverable API errors that provide a retry delay.
+ */
+class RetryAfterApiException extends ErrorApiException
+{
+    private const MILLISECONDS_PER_SECOND = 1000;
+
+    public function __construct(
+        string $errorCode,
+        string $reason,
+        ResponseInterface $response,
+        string $debugId,
+        ?LinkCollection $links = null,
+        ?DetailCollection $details = null,
+        private readonly ?int $retryDelay = null,
+    ) {
+        parent::__construct($errorCode, $reason, $response, $debugId, $links, $details);
+    }
+
+    /**
+     * @return int|null Retry delay in milliseconds
+     */
+    public function getRetryDelay(): ?int
+    {
+        return $this->retryDelay;
+    }
+
+    public static function fromErrorResponse(
+        string $errorCode,
+        string $reason,
+        ResponseInterface $response,
+        string $debugId,
+        ?LinkCollection $links = null,
+        ?DetailCollection $details = null,
+    ): self {
+        return new self(
+            $errorCode,
+            $reason,
+            $response,
+            $debugId,
+            $links,
+            $details,
+            self::parseRetryDelay($response->getHeaderLine('Retry-After') ?: null),
+        );
+    }
+
+    private static function parseRetryDelay(?string $retryAfter): ?int
+    {
+        if ($retryAfter === null || ($retryAfter = \trim($retryAfter)) === '') {
+            return null;
+        }
+
+        if (\ctype_digit($retryAfter)) {
+            $retryDelay = (int) $retryAfter * self::MILLISECONDS_PER_SECOND;
+
+            return $retryDelay > 0 ? $retryDelay : null;
+        }
+
+        $retryAt = \strtotime($retryAfter);
+        if ($retryAt === false) {
+            return null;
+        }
+
+        $retryDelay = ($retryAt - \time()) * self::MILLISECONDS_PER_SECOND;
+
+        return $retryDelay > 0 ? $retryDelay : null;
+    }
+}

--- a/tests/unit/Exception/ExceptionFactoryTest.php
+++ b/tests/unit/Exception/ExceptionFactoryTest.php
@@ -14,12 +14,14 @@ use Shopware\PayPalSDK\Exception\ApiException;
 use Shopware\PayPalSDK\Exception\ErrorApiException;
 use Shopware\PayPalSDK\Exception\ExceptionFactory;
 use Shopware\PayPalSDK\Exception\OAuthApiException;
+use Shopware\PayPalSDK\Exception\RetryAfterApiException;
 use Shopware\PayPalSDK\Struct\Error\Error;
 
 /**
  * @internal
  */
 #[CoversClass(ExceptionFactory::class)]
+#[CoversClass(RetryAfterApiException::class)]
 class ExceptionFactoryTest extends TestCase
 {
     private Psr17Factory $factory;
@@ -116,6 +118,66 @@ class ExceptionFactoryTest extends TestCase
 
         static::assertSame(ApiException::class, $exception::class);
         static::assertSame('The error "UNKNOWN" occurred with the following message: something.', $exception->getMessage());
+    }
+
+    public function testCreateFromResponseWithRetryAfterSeconds(): void
+    {
+        $error = new Error();
+        $error->setName(ApiException::CODE_RATE_LIMIT_REACHED);
+        $error->setMessage('Rate limit reached');
+        $error->setDebugId('1234567890');
+
+        $response = $this->factory
+            ->createResponse()
+            ->withHeader('Retry-After', '120')
+            ->withBody($this->factory->createStream(\json_encode($error, \JSON_THROW_ON_ERROR)))
+            ->withStatus(429);
+
+        $exception = ExceptionFactory::createFromResponse($response);
+
+        static::assertInstanceOf(RetryAfterApiException::class, $exception);
+        static::assertSame(ApiException::CODE_RATE_LIMIT_REACHED, $exception->getErrorCode());
+        static::assertSame(120000, $exception->getRetryDelay());
+    }
+
+    public function testCreateFromResponseWithRetryAfterDate(): void
+    {
+        $error = new Error();
+        $error->setName(ApiException::CODE_RATE_LIMIT_REACHED);
+        $error->setMessage('Rate limit reached');
+        $error->setDebugId('1234567890');
+
+        $response = $this->factory
+            ->createResponse()
+            ->withHeader('Retry-After', (new \DateTimeImmutable('+2 minutes'))->format(\DateTimeInterface::RFC7231))
+            ->withBody($this->factory->createStream(\json_encode($error, \JSON_THROW_ON_ERROR)))
+            ->withStatus(429);
+
+        $exception = ExceptionFactory::createFromResponse($response);
+
+        static::assertInstanceOf(RetryAfterApiException::class, $exception);
+        static::assertNotNull($exception->getRetryDelay());
+        static::assertGreaterThanOrEqual(110000, $exception->getRetryDelay());
+        static::assertLessThanOrEqual(120000, $exception->getRetryDelay());
+    }
+
+    public function testCreateFromResponseWithInvalidRetryAfter(): void
+    {
+        $error = new Error();
+        $error->setName(ApiException::CODE_RATE_LIMIT_REACHED);
+        $error->setMessage('Rate limit reached');
+        $error->setDebugId('1234567890');
+
+        $response = $this->factory
+            ->createResponse()
+            ->withHeader('Retry-After', 'not-a-date')
+            ->withBody($this->factory->createStream(\json_encode($error, \JSON_THROW_ON_ERROR)))
+            ->withStatus(429);
+
+        $exception = ExceptionFactory::createFromResponse($response);
+
+        static::assertInstanceOf(RetryAfterApiException::class, $exception);
+        static::assertNull($exception->getRetryDelay());
     }
 
     public function testCreateFromResponseWihBodyEmpty(): void

--- a/tests/unit/Exception/ExceptionFactoryTest.php
+++ b/tests/unit/Exception/ExceptionFactoryTest.php
@@ -123,7 +123,7 @@ class ExceptionFactoryTest extends TestCase
     public function testCreateFromResponseWithRetryAfterSeconds(): void
     {
         $error = new Error();
-        $error->setName(ApiException::CODE_RATE_LIMIT_REACHED);
+        $error->setName('OTHER_RATE_LIMIT');
         $error->setMessage('Rate limit reached');
         $error->setDebugId('1234567890');
 
@@ -136,8 +136,45 @@ class ExceptionFactoryTest extends TestCase
         $exception = ExceptionFactory::createFromResponse($response);
 
         static::assertInstanceOf(RetryAfterApiException::class, $exception);
+        static::assertSame('OTHER_RATE_LIMIT', $exception->getErrorCode());
+        static::assertNotNull($exception->getRetryAt());
+        static::assertNotNull($exception->getRetryDelay());
+        static::assertGreaterThanOrEqual(110000, $exception->getRetryDelay());
+        static::assertLessThanOrEqual(120000, $exception->getRetryDelay());
+    }
+
+    public function testCreateFromResponseWithRetryAfterWithoutErrorBody(): void
+    {
+        $response = $this->factory
+            ->createResponse()
+            ->withHeader('Retry-After', '120')
+            ->withStatus(429);
+
+        $exception = ExceptionFactory::createFromResponse($response);
+
+        static::assertNotInstanceOf(RetryAfterApiException::class, $exception);
+        static::assertSame(ApiException::class, $exception::class);
+        static::assertSame(ApiException::CODE_UNKNOWN, $exception->getErrorCode());
+        static::assertSame(429, $exception->getStatusCode());
+    }
+
+    public function testCreateFromResponseWithRateLimitCodeWithoutTooManyRequestsStatus(): void
+    {
+        $error = new Error();
+        $error->setName(ApiException::CODE_RATE_LIMIT_REACHED);
+        $error->setMessage('Rate limit reached');
+        $error->setDebugId('1234567890');
+
+        $response = $this->factory
+            ->createResponse()
+            ->withHeader('Retry-After', '120')
+            ->withBody($this->factory->createStream(\json_encode($error, \JSON_THROW_ON_ERROR)))
+            ->withStatus(400);
+
+        $exception = ExceptionFactory::createFromResponse($response);
+
+        static::assertSame(ErrorApiException::class, $exception::class);
         static::assertSame(ApiException::CODE_RATE_LIMIT_REACHED, $exception->getErrorCode());
-        static::assertSame(120000, $exception->getRetryDelay());
     }
 
     public function testCreateFromResponseWithRetryAfterDate(): void
@@ -156,6 +193,7 @@ class ExceptionFactoryTest extends TestCase
         $exception = ExceptionFactory::createFromResponse($response);
 
         static::assertInstanceOf(RetryAfterApiException::class, $exception);
+        static::assertNotNull($exception->getRetryAt());
         static::assertNotNull($exception->getRetryDelay());
         static::assertGreaterThanOrEqual(110000, $exception->getRetryDelay());
         static::assertLessThanOrEqual(120000, $exception->getRetryDelay());
@@ -177,6 +215,7 @@ class ExceptionFactoryTest extends TestCase
         $exception = ExceptionFactory::createFromResponse($response);
 
         static::assertInstanceOf(RetryAfterApiException::class, $exception);
+        static::assertNull($exception->getRetryAt());
         static::assertNull($exception->getRetryDelay());
     }
 

--- a/tests/unit/Exception/RetryAfterApiExceptionTest.php
+++ b/tests/unit/Exception/RetryAfterApiExceptionTest.php
@@ -68,7 +68,7 @@ class RetryAfterApiExceptionTest extends TestCase
         static::assertLessThanOrEqual(120000, $exception->getRetryDelay());
     }
 
-    #[DataProvider('provideInvalidRetryAfterHeaders')]
+    #[DataProvider('provideFromErrorResponseIgnoresInvalidHeaders')]
     public function testFromErrorResponseIgnoresInvalidHeaders(?string $retryAfter): void
     {
         $headers = $retryAfter !== null ? ['Retry-After' => $retryAfter] : [];
@@ -83,7 +83,7 @@ class RetryAfterApiExceptionTest extends TestCase
         static::assertNull($exception->getRetryDelay());
     }
 
-    public static function provideInvalidRetryAfterHeaders(): \Generator
+    public static function provideFromErrorResponseIgnoresInvalidHeaders(): \Generator
     {
         yield 'missing' => [null];
         yield 'empty' => [''];

--- a/tests/unit/Exception/RetryAfterApiExceptionTest.php
+++ b/tests/unit/Exception/RetryAfterApiExceptionTest.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Shopware\PayPalSDK\Tests\Unit\Exception;
+
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\PayPalSDK\Exception\ApiException;
+use Shopware\PayPalSDK\Exception\RetryAfterApiException;
+
+/**
+ * @internal
+ */
+#[CoversClass(RetryAfterApiException::class)]
+class RetryAfterApiExceptionTest extends TestCase
+{
+    public function testGetRetryDelayFromConstructor(): void
+    {
+        $response = new Response(429, body: '{"name":"RATE_LIMIT_REACHED"}');
+
+        $exception = new RetryAfterApiException(
+            ApiException::CODE_RATE_LIMIT_REACHED,
+            'Rate limit reached',
+            $response,
+            'debug-id',
+            retryDelay: 60000,
+        );
+
+        static::assertSame(ApiException::CODE_RATE_LIMIT_REACHED, $exception->getErrorCode());
+        static::assertSame(429, $exception->getStatusCode());
+        static::assertSame('debug-id', $exception->debugId);
+        static::assertSame(60000, $exception->getRetryDelay());
+    }
+
+    public function testFromErrorResponseParsesSecondsHeader(): void
+    {
+        $exception = RetryAfterApiException::fromErrorResponse(
+            ApiException::CODE_RATE_LIMIT_REACHED,
+            'Rate limit reached',
+            new Response(429, ['Retry-After' => '120']),
+            'debug-id',
+        );
+
+        static::assertSame(120000, $exception->getRetryDelay());
+    }
+
+    public function testFromErrorResponseParsesDateHeader(): void
+    {
+        $response = new Response(429, [
+            'Retry-After' => (new \DateTimeImmutable('+2 minutes'))->format(\DateTimeInterface::RFC7231),
+        ]);
+
+        $exception = RetryAfterApiException::fromErrorResponse(
+            ApiException::CODE_RATE_LIMIT_REACHED,
+            'Rate limit reached',
+            $response,
+            'debug-id',
+        );
+
+        static::assertNotNull($exception->getRetryDelay());
+        static::assertGreaterThanOrEqual(110000, $exception->getRetryDelay());
+        static::assertLessThanOrEqual(120000, $exception->getRetryDelay());
+    }
+
+    #[DataProvider('provideInvalidRetryAfterHeaders')]
+    public function testFromErrorResponseIgnoresInvalidHeaders(?string $retryAfter): void
+    {
+        $headers = $retryAfter !== null ? ['Retry-After' => $retryAfter] : [];
+
+        $exception = RetryAfterApiException::fromErrorResponse(
+            ApiException::CODE_RATE_LIMIT_REACHED,
+            'Rate limit reached',
+            new Response(429, $headers),
+            'debug-id',
+        );
+
+        static::assertNull($exception->getRetryDelay());
+    }
+
+    public static function provideInvalidRetryAfterHeaders(): \Generator
+    {
+        yield 'missing' => [null];
+        yield 'empty' => [''];
+        yield 'zero seconds' => ['0'];
+        yield 'invalid date' => ['not-a-date'];
+        yield 'past date' => [(new \DateTimeImmutable('-1 minute'))->format(\DateTimeInterface::RFC7231)];
+    }
+}

--- a/tests/unit/Exception/RetryAfterApiExceptionTest.php
+++ b/tests/unit/Exception/RetryAfterApiExceptionTest.php
@@ -20,7 +20,7 @@ use Shopware\PayPalSDK\Exception\RetryAfterApiException;
 #[CoversClass(RetryAfterApiException::class)]
 class RetryAfterApiExceptionTest extends TestCase
 {
-    public function testGetRetryDelayFromConstructor(): void
+    public function testConstructorParsesSecondsHeader(): void
     {
         $response = new Response(429, body: '{"name":"RATE_LIMIT_REACHED"}');
 
@@ -29,61 +29,53 @@ class RetryAfterApiExceptionTest extends TestCase
             'Rate limit reached',
             $response,
             'debug-id',
-            retryDelay: 60000,
+            retryAfter: '120',
         );
 
         static::assertSame(ApiException::CODE_RATE_LIMIT_REACHED, $exception->getErrorCode());
         static::assertSame(429, $exception->getStatusCode());
         static::assertSame('debug-id', $exception->debugId);
-        static::assertSame(60000, $exception->getRetryDelay());
-    }
-
-    public function testFromErrorResponseParsesSecondsHeader(): void
-    {
-        $exception = RetryAfterApiException::fromErrorResponse(
-            ApiException::CODE_RATE_LIMIT_REACHED,
-            'Rate limit reached',
-            new Response(429, ['Retry-After' => '120']),
-            'debug-id',
-        );
-
-        static::assertSame(120000, $exception->getRetryDelay());
-    }
-
-    public function testFromErrorResponseParsesDateHeader(): void
-    {
-        $response = new Response(429, [
-            'Retry-After' => (new \DateTimeImmutable('+2 minutes'))->format(\DateTimeInterface::RFC7231),
-        ]);
-
-        $exception = RetryAfterApiException::fromErrorResponse(
-            ApiException::CODE_RATE_LIMIT_REACHED,
-            'Rate limit reached',
-            $response,
-            'debug-id',
-        );
-
+        static::assertNotNull($exception->getRetryAt());
         static::assertNotNull($exception->getRetryDelay());
         static::assertGreaterThanOrEqual(110000, $exception->getRetryDelay());
         static::assertLessThanOrEqual(120000, $exception->getRetryDelay());
     }
 
-    #[DataProvider('provideFromErrorResponseIgnoresInvalidHeaders')]
-    public function testFromErrorResponseIgnoresInvalidHeaders(?string $retryAfter): void
+    public function testConstructorParsesDateHeader(): void
     {
-        $headers = $retryAfter !== null ? ['Retry-After' => $retryAfter] : [];
+        $retryAt = new \DateTimeImmutable('+2 minutes');
 
-        $exception = RetryAfterApiException::fromErrorResponse(
+        $exception = new RetryAfterApiException(
             ApiException::CODE_RATE_LIMIT_REACHED,
             'Rate limit reached',
-            new Response(429, $headers),
+            new Response(429),
             'debug-id',
+            retryAfter: $retryAt->format(\DateTimeInterface::RFC7231),
         );
 
+        static::assertNotNull($exception->getRetryAt());
+        static::assertSame($retryAt->getTimestamp(), $exception->getRetryAt()->getTimestamp());
+        static::assertNotNull($exception->getRetryDelay());
+        static::assertGreaterThanOrEqual(110000, $exception->getRetryDelay());
+        static::assertLessThanOrEqual(120000, $exception->getRetryDelay());
+    }
+
+    #[DataProvider('provideConstructorIgnoresInvalidHeaders')]
+    public function testConstructorIgnoresInvalidHeaders(?string $retryAfter): void
+    {
+        $exception = new RetryAfterApiException(
+            ApiException::CODE_RATE_LIMIT_REACHED,
+            'Rate limit reached',
+            new Response(429),
+            'debug-id',
+            retryAfter: $retryAfter,
+        );
+
+        static::assertNull($exception->getRetryAt());
         static::assertNull($exception->getRetryDelay());
     }
 
-    public static function provideFromErrorResponseIgnoresInvalidHeaders(): \Generator
+    public static function provideConstructorIgnoresInvalidHeaders(): \Generator
     {
         yield 'missing' => [null];
         yield 'empty' => [''];


### PR DESCRIPTION
## Description

PayPal can return `429 RATE_LIMIT_REACHED` responses with a `Retry-After` header that tells clients when to retry.

This PR moves the parsing of that header into the SDK by introducing `RetryAfterApiException`. SDK consumers no longer need to inspect raw response headers themselves and can use the parsed retry delay directly.

This keeps rate-limit handling consistent across all integrations using the SDK.