### PR TITLE
fix: make AuthenticationResult::$liabilityShift nullable

### DIFF
--- a/src/Struct/V2/Order/PaymentSource/Card/AuthenticationResult.php
+++ b/src/Struct/V2/Order/PaymentSource/Card/AuthenticationResult.php
@@ -14,18 +14,18 @@ use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource\Card\AuthenticationResult\T
 #[OA\Schema(schema: 'paypal_v2_order_payment_source_card_authentication_result')]
 class AuthenticationResult extends Struct
 {
-    #[OA\Property(type: 'string')]
-    protected string $liabilityShift;
+    #[OA\Property(type: 'string', nullable: true)]
+    protected ?string $liabilityShift = null;
 
     #[OA\Property(ref: ThreeDSecure::class, nullable: true)]
     protected ?ThreeDSecure $threeDSecure = null;
 
-    public function getLiabilityShift(): string
+    public function getLiabilityShift(): ?string
     {
         return $this->liabilityShift;
     }
 
-    public function setLiabilityShift(string $liabilityShift): void
+    public function setLiabilityShift(?string $liabilityShift): void
     {
         $this->liabilityShift = $liabilityShift;
     }


### PR DESCRIPTION
Fixes https://github.com/shopware/paypal-sdk/issues/103

When PayPal determines that 3D Secure is not required for a card (common for US-issued cards), the API response may omit the `liability_shift` field entirely from `authentication_result`. Since the property is typed as non-nullable `string`, deserialization fails when the field is absent.

The `$threeDSecure` property in the same class already handles this correctly by being `?ThreeDSecure`. This PR applies the same pattern to `$liabilityShift`.

**Changes:**
- `$liabilityShift`: `string` → `?string` with `null` default
- `getLiabilityShift()`: `string` return → `?string`
- `setLiabilityShift()`: `string` param → `?string`

**Related:** 
 - shopware/SwagPayPal#714
 - shopware/SwagPayPal#715