### PR TITLE
feat: add confirm payment source to order gateway

### DIFF
--- a/src/Gateway/OrderGateway.php
+++ b/src/Gateway/OrderGateway.php
@@ -8,6 +8,7 @@
 namespace Shopware\PayPalSDK\Gateway;
 
 use Shopware\PayPalSDK\Contract\Context\ApiContextInterface;
+use Shopware\PayPalSDK\Struct\V2\ConfirmOrder;
 use Shopware\PayPalSDK\Struct\V2\Order;
 use Shopware\PayPalSDK\Struct\V2\Order\Tracker;
 use Shopware\PayPalSDK\Struct\V2\Patch;
@@ -58,6 +59,17 @@ class OrderGateway extends AbstractGateway
             null,
             Order::class,
             $context
+        );
+    }
+
+    public function confirmPaymentSource(string $orderId, ConfirmOrder $confirmOrder, ApiContextInterface $context): Order
+    {
+        return $this->request(
+            'POST',
+            self::GATEWAY_URL . '/' . $orderId . '/confirm-payment-source',
+            $confirmOrder,
+            Order::class,
+            $context->withHeader('Prefer', 'return=representation')
         );
     }
 

--- a/src/Struct/V2/ConfirmOrder.php
+++ b/src/Struct/V2/ConfirmOrder.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Shopware\PayPalSDK\Struct\V2;
+
+use OpenApi\Attributes as OA;
+use Shopware\PayPalSDK\Struct\Struct;
+use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource;
+
+#[OA\Schema(schema: 'paypal_v2_confirm_order')]
+class ConfirmOrder extends Struct
+{
+    #[OA\Property(ref: PaymentSource::class)]
+    protected PaymentSource $paymentSource;
+
+    public function getPaymentSource(): PaymentSource
+    {
+        return $this->paymentSource;
+    }
+
+    public function setPaymentSource(PaymentSource $paymentSource): void
+    {
+        $this->paymentSource = $paymentSource;
+    }
+}

--- a/tests/unit/Gateway/OrderGatewayTest.php
+++ b/tests/unit/Gateway/OrderGatewayTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\PayPalSDK\Context\ApiContext;
 use Shopware\PayPalSDK\Context\CredentialsOAuthContext;
 use Shopware\PayPalSDK\Gateway\OrderGateway;
+use Shopware\PayPalSDK\Struct\V2\ConfirmOrder;
 use Shopware\PayPalSDK\Struct\V2\Order;
 use Shopware\PayPalSDK\Struct\V2\Order\Tracker;
 use Shopware\PayPalSDK\Struct\V2\PatchCollection;
@@ -104,6 +105,29 @@ class OrderGatewayTest extends TestCase
         static::assertSame('POST', $last->getRequest()->getMethod());
         static::assertSame('/v2/checkout/orders/orderId/capture', $last->getRequest()->getUri()->getPath());
         static::assertSame('', (string) $last->getRequest()->getBody());
+    }
+
+    public function testConfirmPaymentSource(): void
+    {
+        $context = new ApiContext(new CredentialsOAuthContext('client-id', 'client-secret'), true, 'merchant-id');
+        $body = (new Order())->assign(['id' => 'some-order-id']);
+
+        $confirmOrder = new ConfirmOrder();
+        $confirmOrder->setPaymentSource((new Order\PaymentSource())->assign([]));
+
+        $this->gateways->setCachedToken($context);
+        $this->client->addResponse(new Response(body: \json_encode($body, \JSON_THROW_ON_ERROR)));
+
+        $response = $this->gateways->orderGateway()->confirmPaymentSource('orderId', $confirmOrder, $context);
+        static::assertEquals($body, $response);
+
+        $last = $this->client->getLast();
+        static::assertNotNull($last);
+        static::assertSame('POST', $last->getRequest()->getMethod());
+        static::assertSame('/v2/checkout/orders/orderId/confirm-payment-source', $last->getRequest()->getUri()->getPath());
+        static::assertSame('return=representation', $last->getRequest()->getHeaderLine('Prefer'));
+        static::assertSame(\json_encode($confirmOrder), (string) $last->getRequest()->getBody());
+        static::assertStringContainsString('"payment_source"', (string) $last->getRequest()->getBody());
     }
 
     public function testPatchOrder(): void


### PR DESCRIPTION
Backport of #105 to 1.x. Needs #108 merged first so bc-check runs on the fixed tooling.