### PR TITLE
fix: support swagger-php 6.4 in schema tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "phpunit/phpunit": "^11.5",
         "phpstan/phpstan-phpunit": "^2.0",
         "monolog/monolog": "^3.9",
-        "zircote/swagger-php": "^5.0",
+        "zircote/swagger-php": "^5.0 || ^6.4",
         "guzzlehttp/psr7": "^2.7",
         "php-http/guzzle7-adapter": "^1.1",
         "phpstan/phpstan-strict-rules": "^2.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d5c71bc8a70642e01ea0e467c4ba42f1",
+    "content-hash": "0436b4fe44bcfbba2257181fd602d8b6",
     "packages": [
         {
             "name": "php-http/discovery",
@@ -2613,6 +2613,68 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
             "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "radebatz/type-info-extras",
+            "version": "1.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DerManoMann/type-info-extras.git",
+                "reference": "95a524a74a61648b44e355cb33d38db4b17ef5ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DerManoMann/type-info-extras/zipball/95a524a74a61648b44e355cb33d38db4b17ef5ce",
+                "reference": "95a524a74a61648b44e355cb33d38db4b17ef5ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "phpstan/phpdoc-parser": "^2.0",
+                "symfony/type-info": "^7.3.8 || ^7.4.1 || ^8.0 || ^8.1-@dev"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.70",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Radebatz\\TypeInfoExtras\\": "src"
+                },
+                "exclude-from-classmap": [
+                    "/tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Martin Rademacher",
+                    "email": "mano@radebatz.org"
+                }
+            ],
+            "description": "Extras for symfony/type-info",
+            "homepage": "http://radebatz.net/mano/",
+            "keywords": [
+                "component",
+                "symfony",
+                "type-info",
+                "types"
+            ],
+            "support": {
+                "issues": "https://github.com/DerManoMann/type-info-extras/issues",
+                "source": "https://github.com/DerManoMann/type-info-extras/tree/1.0.7"
+            },
+            "time": "2026-03-06T22:40:29+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -5646,6 +5708,89 @@
             "time": "2025-11-27T13:27:24+00:00"
         },
         {
+            "name": "symfony/type-info",
+            "version": "v7.4.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/type-info.git",
+                "reference": "cafeedbf157b890e94ac5b83eaed85595106d5d6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/type-info/zipball/cafeedbf157b890e94ac5b83eaed85595106d5d6",
+                "reference": "cafeedbf157b890e94ac5b83eaed85595106d5d6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "phpstan/phpdoc-parser": "<1.30"
+            },
+            "require-dev": {
+                "phpstan/phpdoc-parser": "^1.30|^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\TypeInfo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mathias Arlaud",
+                    "email": "mathias.arlaud@gmail.com"
+                },
+                {
+                    "name": "Baptiste LEDUC",
+                    "email": "baptiste.leduc@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Extracts PHP types information.",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "PHPStan",
+                "phpdoc",
+                "symfony",
+                "type"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/type-info/tree/v7.4.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-22T15:21:55+00:00"
+        },
+        {
             "name": "symfony/yaml",
             "version": "v7.4.0",
             "source": {
@@ -5888,24 +6033,25 @@
         },
         {
             "name": "zircote/swagger-php",
-            "version": "5.7.5",
+            "version": "6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zircote/swagger-php.git",
-                "reference": "9a37739401485b42d779495e70548309820d11d6"
+                "reference": "d2006242dae81ae8833ad9a0ffb74e3254654cff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/9a37739401485b42d779495e70548309820d11d6",
-                "reference": "9a37739401485b42d779495e70548309820d11d6",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/d2006242dae81ae8833ad9a0ffb74e3254654cff",
+                "reference": "d2006242dae81ae8833ad9a0ffb74e3254654cff",
                 "shasum": ""
             },
             "require": {
-                "ext-json": "*",
                 "nikic/php-parser": "^4.19 || ^5.0",
-                "php": ">=7.4",
+                "php": ">=8.2",
                 "phpstan/phpdoc-parser": "^2.0",
                 "psr/log": "^1.1 || ^2.0 || ^3.0",
+                "radebatz/type-info-extras": "^1.0.2",
+                "symfony/console": "^7.4 || ^8.0",
                 "symfony/deprecation-contracts": "^2 || ^3",
                 "symfony/finder": "^5.0 || ^6.0 || ^7.0 || ^8.0",
                 "symfony/yaml": "^5.4 || ^6.0 || ^7.0 || ^8.0"
@@ -5914,17 +6060,11 @@
                 "symfony/process": ">=6, <6.4.14"
             },
             "require-dev": {
-                "composer/package-versions-deprecated": "^1.11",
                 "doctrine/annotations": "^2.0",
                 "friendsofphp/php-cs-fixer": "^3.62.0",
-                "phpstan/phpstan": "^1.6 || ^2.0",
-                "phpunit/phpunit": "^9.0",
-                "rector/rector": "^1.0 || ^2.0",
-                "vimeo/psalm": "^4.30 || ^5.0"
-            },
-            "suggest": {
-                "doctrine/annotations": "^2.0",
-                "radebatz/type-info-extras": "^1.0.2"
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.5 || >=12.5.22",
+                "rector/rector": "^2.3.1"
             },
             "bin": [
                 "bin/openapi"
@@ -5932,7 +6072,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.x-dev"
+                    "dev-master": "6.x-dev"
                 }
             },
             "autoload": {
@@ -5970,9 +6110,15 @@
             ],
             "support": {
                 "issues": "https://github.com/zircote/swagger-php/issues",
-                "source": "https://github.com/zircote/swagger-php/tree/5.7.5"
+                "source": "https://github.com/zircote/swagger-php/tree/6.4.0"
             },
-            "time": "2025-11-28T23:22:21+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/zircote",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-12T03:44:54+00:00"
         }
     ],
     "aliases": [],

--- a/tests/integration/Struct/OpenAPISchemaTest.php
+++ b/tests/integration/Struct/OpenAPISchemaTest.php
@@ -166,7 +166,13 @@ class OpenAPISchemaTest extends TestCase
             return $schema instanceof Schema ? $schema : null;
         }
 
-        return $this->oa->_analysis->getSchemaForSource($class);
+        if (!\method_exists($this->oa->_analysis, 'getSchemaForSource')) {
+            return null;
+        }
+
+        $schema = (new \ReflectionMethod($this->oa->_analysis, 'getSchemaForSource'))->invoke($this->oa->_analysis, $class);
+
+        return $schema instanceof Schema ? $schema : null;
     }
 
     private function namespaceToSchema(string $fqdn): string

--- a/tests/integration/Struct/OpenAPISchemaTest.php
+++ b/tests/integration/Struct/OpenAPISchemaTest.php
@@ -12,6 +12,7 @@ use Monolog\Level;
 use Monolog\Logger;
 use Monolog\LogRecord;
 use OpenApi\Annotations\OpenApi;
+use OpenApi\Annotations\Schema;
 use OpenApi\Attributes\Property;
 use OpenApi\Generator;
 use PHPUnit\Framework\Attributes\CoversNothing;
@@ -58,9 +59,7 @@ class OpenAPISchemaTest extends TestCase
             static::assertDirectoryExists($dir);
         }
 
-        $oa = Generator::scan(self::DIRS, [
-            'logger' => $logger,
-        ]);
+        $oa = (new Generator($logger))->generate(self::DIRS);
 
         static::assertInstanceOf(OpenApi::class, $oa, 'OpenAPI schema could not be generated.');
 
@@ -72,7 +71,7 @@ class OpenAPISchemaTest extends TestCase
         $failures = [];
 
         foreach ($this->oa->_analysis->classes as $class => $classContext) {
-            $schema = $this->oa->_analysis->getSchemaForSource($class);
+            $schema = $this->schemaForSource($class);
 
             if (!$schema?->schema || $schema->schema === Generator::UNDEFINED) {
                 continue;
@@ -114,7 +113,7 @@ class OpenAPISchemaTest extends TestCase
         $failures = [];
 
         foreach ($this->oa->_analysis->classes as $class => $classContext) {
-            $schema = $this->oa->_analysis->getSchemaForSource($class);
+            $schema = $this->schemaForSource($class);
 
             if (!$schema?->schema || $schema->schema === Generator::UNDEFINED) {
                 continue;
@@ -135,7 +134,7 @@ class OpenAPISchemaTest extends TestCase
         $failures = [];
 
         foreach ($this->oa->_analysis->classes as $class => $classContext) {
-            $schema = $this->oa->_analysis->getSchemaForSource($class);
+            $schema = $this->schemaForSource($class);
 
             if (!$schema?->schema || $schema->schema === Generator::UNDEFINED || !\class_exists($class)) {
                 continue;
@@ -157,6 +156,17 @@ class OpenAPISchemaTest extends TestCase
         }
 
         static::assertEmpty($failures, \implode(\PHP_EOL, $failures));
+    }
+
+    private function schemaForSource(string $class): ?Schema
+    {
+        if (\method_exists($this->oa->_analysis, 'getAnnotationForSource')) {
+            $schema = $this->oa->_analysis->getAnnotationForSource($class, Schema::class);
+
+            return $schema instanceof Schema ? $schema : null;
+        }
+
+        return $this->oa->_analysis->getSchemaForSource($class);
     }
 
     private function namespaceToSchema(string $fqdn): string


### PR DESCRIPTION
Closes #107.

## Summary
- allow the dev dependency to resolve zircote/swagger-php 6.4
- migrate OpenAPI schema generation from the removed static scan API to Generator::generate()
- use the current source-to-schema lookup API with a fallback for swagger-php 5
- keep swagger-php scoped to SDK development/tests, not production installs

## Tests
- vendor/bin/phpstan analyze --memory-limit=2G
- vendor/bin/phpunit --testsuite=IntegrationTest
- composer validate --strict