### PR TITLE
feat: map CHECKOUT.PAYMENT-APPROVAL.REVERSED resource by event type

### DIFF
--- a/src/Struct/V1/Webhook/Event.php
+++ b/src/Struct/V1/Webhook/Event.php
@@ -15,6 +15,7 @@ use Shopware\PayPalSDK\Struct\V1\Subscription;
 use Shopware\PayPalSDK\Struct\V1\Webhook\Events\AccountEntities;
 use Shopware\PayPalSDK\Struct\V1\Webhook\Events\Dispute;
 use Shopware\PayPalSDK\Struct\V1\Webhook\Events\ManagedAccounts;
+use Shopware\PayPalSDK\Struct\V1\Webhook\Events\PaymentApprovalReversed;
 use Shopware\PayPalSDK\Struct\V2\Order;
 use Shopware\PayPalSDK\Struct\V2\Order\PurchaseUnit\Payments\Authorization;
 use Shopware\PayPalSDK\Struct\V2\Order\PurchaseUnit\Payments\Capture;
@@ -58,6 +59,7 @@ class Event extends Struct
         new OA\Schema(ref: ManagedAccounts::class),
         new OA\Schema(ref: AccountEntities::class),
         new OA\Schema(ref: Dispute::class),
+        new OA\Schema(ref: PaymentApprovalReversed::class),
     ])]
     protected ?Struct $resource = null;
 
@@ -82,7 +84,16 @@ class Event extends Struct
         unset($data['resource']);
         $webhook = parent::assign($data);
 
-        if (\is_array($resourceData) && $resourceClass = $this->identifyResourceType($this->resourceVersion, $this->resourceType)) {
+        if (!\is_array($resourceData)) {
+            return $webhook;
+        }
+
+        // PAYMENT-APPROVAL.REVERSED uses order_id (not id) and often omits resource_type.
+        $resourceClass = $this->eventType === WebhookEventTypes::CHECKOUT_PAYMENT_APPROVAL_REVERSED
+            ? PaymentApprovalReversed::class
+            : $this->identifyResourceType($this->resourceVersion, $this->resourceType);
+
+        if ($resourceClass !== null) {
             $webhook->resource = Struct::from($resourceClass, $resourceData);
         }
 

--- a/src/Struct/V1/Webhook/Events/PaymentApprovalReversed.php
+++ b/src/Struct/V1/Webhook/Events/PaymentApprovalReversed.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+/*
+ * (c) shopware AG <info@shopware.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Shopware\PayPalSDK\Struct\V1\Webhook\Events;
+
+use OpenApi\Attributes as OA;
+use Shopware\PayPalSDK\Struct\Struct;
+use Shopware\PayPalSDK\Struct\V2\Order\PaymentSource;
+use Shopware\PayPalSDK\Struct\V2\Order\PurchaseUnit;
+use Shopware\PayPalSDK\Struct\V2\Order\PurchaseUnitCollection;
+
+/**
+ * Resource shape for {@see \Shopware\PayPalSDK\Struct\V1\Webhook\WebhookEventTypes::CHECKOUT_PAYMENT_APPROVAL_REVERSED}.
+ *
+ * PayPal sends `order_id` (not `id`) on this event and often omits `resource_type`,
+ * so {@see \Shopware\PayPalSDK\Struct\V1\Webhook\Event::assign()} maps by event type.
+ */
+#[OA\Schema(schema: 'paypal_v1_webhook_events_payment_approval_reversed')]
+class PaymentApprovalReversed extends Struct
+{
+    #[OA\Property(type: 'string')]
+    protected string $orderId;
+
+    #[OA\Property(type: 'array', items: new OA\Items(ref: PurchaseUnit::class), nullable: true)]
+    protected ?PurchaseUnitCollection $purchaseUnits = null;
+
+    #[OA\Property(ref: PaymentSource::class, nullable: true)]
+    protected ?PaymentSource $paymentSource = null;
+
+    public function getOrderId(): string
+    {
+        return $this->orderId;
+    }
+
+    public function setOrderId(string $orderId): void
+    {
+        $this->orderId = $orderId;
+    }
+
+    public function getPurchaseUnits(): ?PurchaseUnitCollection
+    {
+        return $this->purchaseUnits;
+    }
+
+    public function setPurchaseUnits(?PurchaseUnitCollection $purchaseUnits): void
+    {
+        $this->purchaseUnits = $purchaseUnits;
+    }
+
+    public function getPaymentSource(): ?PaymentSource
+    {
+        return $this->paymentSource;
+    }
+
+    public function setPaymentSource(?PaymentSource $paymentSource): void
+    {
+        $this->paymentSource = $paymentSource;
+    }
+}

--- a/tests/unit/Struct/V1/Webhook/EventTest.php
+++ b/tests/unit/Struct/V1/Webhook/EventTest.php
@@ -16,7 +16,9 @@ use Shopware\PayPalSDK\Struct\V1\Webhook\Event;
 use Shopware\PayPalSDK\Struct\V1\Webhook\Events\AccountEntities;
 use Shopware\PayPalSDK\Struct\V1\Webhook\Events\Dispute;
 use Shopware\PayPalSDK\Struct\V1\Webhook\Events\ManagedAccounts;
+use Shopware\PayPalSDK\Struct\V1\Webhook\Events\PaymentApprovalReversed;
 use Shopware\PayPalSDK\Struct\V1\Webhook\Resource;
+use Shopware\PayPalSDK\Struct\V1\Webhook\WebhookEventTypes;
 use Shopware\PayPalSDK\Struct\V2\Order;
 use Shopware\PayPalSDK\Struct\V2\Order\PurchaseUnit\Payments\Authorization;
 use Shopware\PayPalSDK\Struct\V2\Order\PurchaseUnit\Payments\Capture;
@@ -100,6 +102,41 @@ class EventTest extends TestCase
         static::assertInstanceOf(Order::class, $resource);
         static::assertSame('4UX51220T4035005S', $resource->getId());
         static::assertSame('COMPLETED', $resource->getStatus());
+    }
+
+    public function testPaymentApprovalReversedResourceUsesOrderId(): void
+    {
+        $event = Struct::from(Event::class, [
+            'id' => 'WH-COC11055RA711503B-4YM959094A144403T',
+            'event_type' => WebhookEventTypes::CHECKOUT_PAYMENT_APPROVAL_REVERSED,
+            'summary' => 'A payment has been reversed after approval.',
+            'resource' => [
+                'order_id' => '5O190127TN364715T',
+                'purchase_units' => [
+                    [
+                        'reference_id' => 'd9f80740-38f0-11e8-b467-0ed5f89f718b',
+                        'custom_id' => 'MERCHANT_CUSTOM_ID',
+                        'invoice_id' => 'MERCHANT_INVOICE_ID',
+                    ],
+                ],
+                'payment_source' => [
+                    'ideal' => [
+                        'name' => 'John Doe',
+                        'country_code' => 'NL',
+                    ],
+                ],
+            ],
+            'create_time' => '2020-01-25T21:21:49.000Z',
+            'event_version' => '1.0',
+            'links' => [],
+        ]);
+
+        $resource = $event->getResource();
+        static::assertNotNull($resource);
+        static::assertInstanceOf(PaymentApprovalReversed::class, $resource);
+        static::assertSame('5O190127TN364715T', $resource->getOrderId());
+        static::assertSame('MERCHANT_CUSTOM_ID', $resource->getPurchaseUnits()?->first()?->getCustomId());
+        static::assertNotNull($resource->getPaymentSource()?->getIdeal());
     }
 
     public function testDisputeResourcePreservesFields(): void


### PR DESCRIPTION
## Summary
- Add `PaymentApprovalReversed` webhook resource (`order_id` + purchase units).
- Map it in `Event::assign()` by event type, since PayPal often omits `resource_type` and uses `order_id` instead of `id`.

## Test plan
- [x] `vendor/bin/phpunit tests/unit/Struct/V1/Webhook/EventTest.php --filter PaymentApprovalReversed`
